### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,8 @@ CI/CD integration (e.g., GitHub Actions)
 Happy to help!
 
 # The testbed.yaml file works with the Cisco DevNet Cisco Modeling Labs (CML) Sandbox! 
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/automateyournetwork-pyats-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/automateyournetwork-pyats-mcp).