### PR TITLE
Fix ModuleNotFoundError: pkg_resources in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,15 @@ COPY requirements.txt .
 RUN echo "==> Installing pyATS and other Python packages..." \
     && pip install --no-cache-dir -r requirements.txt
 
+# pyats[full]'s dependency resolution pulls in setuptools>=81, which removed
+# the pkg_resources module entirely. genie/unicon still import pkg_resources
+# at runtime, causing "ModuleNotFoundError: No module named 'pkg_resources'"
+# when the server starts. Pin to the last setuptools release that still
+# ships pkg_resources, installed last so nothing above it can upgrade it
+# again.
+RUN echo "==> Pinning setuptools<81 (last release shipping pkg_resources)..." \
+    && pip install --no-cache-dir --force-reinstall "setuptools<81"
+
 # Copy your application code into the container's working directory
 COPY pyats_mcp_server.py .
 


### PR DESCRIPTION
## Summary
- The Docker image built from this repo's `Dockerfile` crashes on startup with `ModuleNotFoundError: No module named 'pkg_resources'`.
- Root cause: `pyats[full]==25.2.0`'s dependency resolution (via `requirements.txt`) pulls in `setuptools>=81`, which removed the `pkg_resources` module entirely. `genie`/`unicon` (pyATS dependencies) still import `pkg_resources` at runtime, so the server dies before it can start.
- Fix: pin `setuptools<81` (the last release line that still ships `pkg_resources`) as the final pip install step, after `requirements.txt`, so nothing earlier in the dependency chain can pull in a newer, incompatible version.

## Test plan
- [x] Built the image from this branch's Dockerfile
- [x] Confirmed `pkg_resources` is importable inside the built image (previously failed with `ModuleNotFoundError`)
- [x] Ran the container with `PYATS_TESTBED_PATH` set and a testbed mounted — server now starts and logs `Starting pyATS MCP Server…` instead of crashing on import
