### PR TITLE
Modernize to MCP Streamable HTTP and add 9 new pyATS/Genie tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,26 @@ PYATS_MCP_CONN_CACHE_TTL=0
 PYATS_MCP_OP_LOG_MAX=500
 
 # -----------------------------------------------------------------------------
+# Transport — Streamable HTTP only (STDIO is not supported)
+# -----------------------------------------------------------------------------
+
+# "stateful" (default) or "stateless" — see README's Configuration section.
+PYATS_MCP_TRANSPORT_MODE=stateful
+
+# Default: 0.0.0.0
+PYATS_MCP_HTTP_HOST=0.0.0.0
+
+# Default: 8080
+PYATS_MCP_HTTP_PORT=8080
+
+# -----------------------------------------------------------------------------
+# XPresso REST API — optional, only needed for pyats_xpresso_request
+# -----------------------------------------------------------------------------
+# XPRESSO_URL=https://xpresso.example.com
+# XPRESSO_API_TOKEN=
+# XPRESSO_GROUP=
+
+# -----------------------------------------------------------------------------
 # Connection defaults
 #
 # These MCP defaults are applied ONLY when the testbed does NOT define a value.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.10-slim
 
 LABEL maintainer="Your Name <you@example.com>"
-LABEL description="Docker image for pyATS MCP Server interacting via stdio"
+LABEL description="Docker image for pyATS MCP Server (Streamable HTTP)"
 
 # Install system dependencies required by pyATS, SSH, and your script
 # Combine update, install, and cleanup in one layer to optimize image size
@@ -58,6 +58,9 @@ COPY pyats_mcp_server.py .
 
 # Optional: If you have other files needed by the script (e.g., commands.json), copy them too
 # COPY commands.json .
+
+# Streamable HTTP — override PYATS_MCP_HTTP_PORT to change this
+EXPOSE 8080
 
 # Define the entrypoint to run your server script
 ENTRYPOINT ["python", "pyats_mcp_server.py"]

--- a/README.md
+++ b/README.md
@@ -3,10 +3,27 @@
 
 [![Available on CodeGuilds](https://img.shields.io/badge/Available_on-CodeGuilds-6366f1)](https://codeguilds.dev/packages/pyats-mcp)
 
+Cisco pyATS and Genie already know how to talk to a network — parsing show commands, pushing configuration, learning feature state, running declarative tests. What they didn't have was a way for an AI agent to drive any of it directly. This server closes that gap: it wraps pyATS/Genie as a set of structured, guarded MCP tools that an agent like Claude can call against a real testbed, over the Model Context Protocol's current Streamable HTTP transport.
 
-MCP server that wraps Cisco pyATS and Genie, letting AI agents (Claude, LangGraph, etc.) run show commands, apply configuration, and query network state over STDIO using JSON-RPC 2.0.
+Point an agent at it and it can look up a device, run and parse a show command, apply configuration with a rollback point, learn and diff a feature's state before and after a change, fan a command out across a fleet — one thread pool or one process per device — run a declarative Blitz or Robot Framework test, or call a device's REST/RESTCONF API directly. Every risky path is guarded before it reaches a device, and every call lands in an in-memory audit log the agent can review mid-session.
 
-> All communication is via STDIN/STDOUT — no HTTP ports, no REST endpoints.
+---
+
+## At a glance
+
+- **Transport** — Streamable HTTP (`mcp>=2.0.0`), stateful or stateless, chosen with one environment variable. STDIO is gone.
+- **26 tools** across discovery, show commands, configuration, Genie learn/diff, Genie Clean, declarative testing (Blitz, Robot Framework, AEtest), generic REST/RESTCONF, and Cisco XPresso.
+- **Two ways to fan out** a command across many devices — a shared thread pool for everyday use, or one OS process per device (`pyats.async_.pcall`) when you want real isolation at scale.
+- **Guardrails, not honor systems** — dangerous commands are blocked before they reach a device, Genie Clean can never run a stage that reboots or reimages one, and destructive actions require an exact confirmation phrase.
+- **Nothing hard-coded** — every credential and device detail lives in `.env`, pulled into `testbed.yaml` at runtime via `%ENV{}` substitution.
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- A pyATS `testbed.yaml` pointed at real or virtual network devices — a physical lab, Cisco Modeling Labs / VIRL / GNS3, or anything else Unicon can reach over SSH/Telnet. pyATS MCP doesn't simulate a network; it drives one.
+- An MCP-capable client to talk to it — see [Connect Your Agent](#connect-your-agent) below.
 
 ---
 
@@ -22,9 +39,11 @@ pip install -r requirements.txt
 cp .env.example .env
 # Edit .env — see Configuration below
 
-# 3. Run
+# 3. Run — starts a Streamable HTTP server on 0.0.0.0:8080 by default
 python3 pyats_mcp_server.py
 ```
+
+The MCP endpoint is then reachable at `http://<host>:<port>/mcp`.
 
 ---
 
@@ -47,7 +66,19 @@ PYATS_MCP_KEEP_ARTIFACTS=1        # 1 = keep, 0 = delete after each run
 PYATS_MCP_TESTBED_CACHE_TTL=30    # seconds before testbed reloads from disk
 PYATS_MCP_CONN_CACHE_TTL=0        # seconds to keep connections alive (0 = off)
 PYATS_MCP_OP_LOG_MAX=500          # max entries in the in-memory operation log
+
+# Transport (Streamable HTTP only — STDIO is not supported)
+PYATS_MCP_TRANSPORT_MODE=stateful # stateful (default) | stateless
+PYATS_MCP_HTTP_HOST=0.0.0.0
+PYATS_MCP_HTTP_PORT=8080
+
+# Optional — only needed for pyats_xpresso_request
+XPRESSO_URL=
+XPRESSO_API_TOKEN=
+XPRESSO_GROUP=
 ```
+
+`PYATS_MCP_TRANSPORT_MODE=stateless` sets `stateless_http=True` on the Streamable HTTP transport, so no server-side session state is retained between requests from clients still negotiating the older, handshake-based protocol. Clients speaking the current MCP protocol (2026-07-28, SEP-2575) are handshake-free by default regardless of this setting — that comes from the `mcp>=2.0.0` SDK itself, not anything configured here.
 
 ### 3. Add a block for each device
 
@@ -84,7 +115,7 @@ LINUX1_PASSWORD=s3cr3t
 # (no enable password for Linux)
 ```
 
-If a group of devices shares credentials you can define group-level vars and reference them across devices:
+If a group of devices shares credentials, define group-level vars and reference them across devices:
 
 ```dotenv
 SITE_A_USERNAME=netops
@@ -133,76 +164,191 @@ docker build -t pyats-mcp-server .
 ### Run (pass .env directly)
 
 ```bash
-docker run -i --rm \
+docker run -p 8080:8080 --rm \
   --env-file /absolute/path/to/.env \
   -v /absolute/path/to/testbed.yaml:/app/testbed.yaml \
   pyats-mcp-server
 ```
 
-### MCP client config (Docker)
+Either way, the server is a long-running process you start once and point clients at — it isn't something an agent spawns per session. See below for exactly how each client connects to it.
+
+---
+
+## Connect Your Agent
+
+The server exposes one thing: an MCP endpoint at `http://<host>:<port>/mcp` (Streamable HTTP). Every client below just needs that URL — no `command`/`args`, no local process for the client to manage.
+
+### Claude Code
+
+```bash
+claude mcp add --transport http pyats http://localhost:8080/mcp
+
+# Behind auth (e.g. a reverse proxy in front of the server)
+claude mcp add --transport http pyats http://localhost:8080/mcp \
+  --header "Authorization: Bearer your-token"
+```
+
+Or drop it straight into `.mcp.json` (project-scoped, committed to the repo) or `~/.claude.json` (user-scoped):
+
+```json
+{
+  "mcpServers": {
+    "pyats": { "type": "http", "url": "http://localhost:8080/mcp" }
+  }
+}
+```
+
+### VS Code (GitHub Copilot Chat)
+
+Add a `.vscode/mcp.json` in the workspace (or run **MCP: Add Server** from the Command Palette):
+
+```json
+{
+  "servers": {
+    "pyats": { "type": "http", "url": "http://localhost:8080/mcp" }
+  }
+}
+```
+
+### OpenAI Codex CLI
+
+```bash
+codex mcp add pyats --url http://localhost:8080/mcp
+```
+
+Or in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pyats]
+url = "http://localhost:8080/mcp"
+```
+
+### Claude Desktop
+
+Claude Desktop's `claude_desktop_config.json` is stdio-only — putting a `url` field in it doesn't work (it's a known issue, not a supported path). Remote/HTTP servers are added instead as a **Custom Connector** under Settings → Connectors, and Desktop connects to it from Anthropic's cloud, not your local machine — so it needs a real, publicly-reachable HTTPS URL, not `localhost`.
+
+To point Desktop at a server running on your own machine anyway, bridge it through [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) as a local stdio proxy:
 
 ```json
 {
   "mcpServers": {
     "pyats": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm",
-        "--env-file", "/absolute/path/to/.env",
-        "-v", "/absolute/path/to/testbed.yaml:/app/testbed.yaml",
-        "pyats-mcp-server"
-      ]
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:8080/mcp", "--transport", "http-only"]
     }
   }
 }
 ```
 
-### MCP client config (local Python)
+### Raw Python (LangGraph, custom agents, anything else)
 
-```json
-{
-  "mcpServers": {
-    "pyats": {
-      "command": "python3",
-      "args": ["-u", "/path/to/pyats_mcp_server.py"],
-      "env": {
-        "PYATS_TESTBED_PATH": "/absolute/path/to/testbed.yaml"
-      }
-    }
-  }
-}
+```python
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+async def main():
+    async with streamablehttp_client("http://localhost:8080/mcp") as (read, write, _session_id):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            result = await session.call_tool(
+                "pyats_run_show_command",
+                arguments={"device_name": "CORE1", "command": "show version"},
+            )
 ```
+
+---
+
+## What To Ask It
+
+Once connected, talk to it like you'd talk to someone who already knows the network:
+
+- *"What devices are in the testbed?"* → `pyats_list_devices`
+- *"Show me the BGP summary on CORE1"* → `pyats_run_show_command`, parsed into structured JSON
+- *"Snapshot CORE1's OSPF state, then apply this config and show me what changed"* → `pyats_learn_feature` (before) → `pyats_configure_with_diff` → `pyats_learn_feature` (after) → `pyats_diff_learned_snapshots`
+- *"Run `show ip interface brief` across every switch"* → `pyats_run_show_command_multi` (or `pyats_pcall_show_command` for process-per-device isolation at real scale)
+- *"If that config change breaks anything, roll it back"* → `pyats_rollback_config`
+- *"Run this Blitz test against R1 and R2"* / *"Run this Robot Framework suite"* → `pyats_run_blitz` / `pyats_run_robot`
+
+The agent chains these itself — you describe the outcome, it picks the tools.
 
 ---
 
 ## Available Tools
 
+26 tools, grouped by what they do.
+
+**Discovery**
+
 | Tool | Description |
 |------|-------------|
 | `pyats_list_devices` | List all devices in the testbed |
 | `pyats_search_devices` | Fuzzy-search devices by name or alias |
+
+**Show commands**
+
+| Tool | Description |
+|------|-------------|
 | `pyats_run_show_command` | Run a validated show command; returns parsed JSON or raw output |
-| `pyats_run_show_command_on_multiple_devices` | Run a show command across multiple devices concurrently |
+| `pyats_run_show_command_multi` | Run a show command across multiple devices concurrently (thread pool) |
+| `pyats_pcall_show_command` | Same, but one OS process per device (`pyats.async_.pcall`) instead of a shared thread pool |
+| `pyats_show_running_config` | Retrieve the full running configuration (raw text) |
+| `pyats_show_logging` | Retrieve device system logs via `show logging` |
 | `pyats_ping_from_network_device` | Execute a ping from a network device |
 | `pyats_run_linux_command` | Run a command on a Linux host |
+
+**Configuration**
+
+| Tool | Description |
+|------|-------------|
 | `pyats_configure_device` | Apply configuration commands with safety guardrails |
-| `pyats_configure_devices_multi` | Apply configuration across multiple devices concurrently |
+| `pyats_configure_devices_multi` | Apply configuration across multiple devices concurrently (thread pool) |
+| `pyats_pcall_configure_devices` | Same, but one OS process per device |
 | `pyats_configure_with_diff` | Apply config and return a before/after diff |
 | `pyats_rollback_config` | Roll back to the last saved configuration snapshot |
+
+**State & diagnostics**
+
+| Tool | Description |
+|------|-------------|
 | `pyats_device_health` | Snapshot CPU, memory, interfaces, and routing state |
 | `pyats_get_neighbors` | Retrieve CDP/LLDP neighbors |
 | `pyats_find_interface_by_ip` | Find which interface owns a given IP address |
-| `pyats_run_dynamic_test` | Execute a sandboxed pyATS test script |
+| `pyats_learn_feature` | Genie `device.learn()` for a whole feature (interface, ospf, bgp, …), optionally saved as a named snapshot |
+| `pyats_diff_learned_snapshots` | Diff two snapshots saved by `pyats_learn_feature` |
+
+**Testing & automation**
+
+| Tool | Description |
+|------|-------------|
+| `pyats_clean_device` | Genie Clean (Kleenex), restricted to non-destructive `connect`+`execute_command` stages; `dry_run=True` by default |
+| `pyats_run_blitz` | Run a declarative pyATS Blitz YAML test |
+| `pyats_run_robot` | Run a Robot Framework suite using the `pyats.robot`/`genie.libs.robot` keyword libraries |
+| `pyats_run_dynamic_test` | Execute a sandboxed pyATS AEtest script |
+
+**APIs**
+
+| Tool | Description |
+|------|-------------|
+| `pyats_rest_request` | Generic REST/RESTCONF/NX-API call via pyATS's `rest.connector` (a separate connection type from CLI/SSH) |
+| `pyats_xpresso_request` | Authenticated call to Cisco XPresso's REST API v2 (test requests, jobs, testbeds, images, …) |
+
+**Session**
+
+| Tool | Description |
+|------|-------------|
 | `pyats_get_operation_log` | Retrieve the in-memory operation log |
 
 ---
 
 ## Security
 
-- Show commands are validated — pipes, redirects, and dangerous keywords are blocked
-- Config changes are checked for `reload`, `erase`, `write erase`, `delete`, `format`
-- Dynamic test scripts run in a restricted sandbox (banned imports: `os`, `sys`, `subprocess`, etc.)
-- All credentials come from `.env` — never stored in the testbed file or source code
+- Show commands are validated — pipes, redirects, and dangerous keywords are blocked.
+- Config changes are checked for `reload`, `erase`, `write erase`, `delete`, `format` — the same check runs inside `pyats_clean_device`, `pyats_run_blitz`, and `pyats_run_robot`.
+- Dynamic test scripts run in a restricted sandbox (banned imports: `os`, `sys`, `subprocess`, etc.).
+- `pyats_clean_device` never runs a real Genie Clean stage that reboots, erases, or reimages a device — only `connect`+`execute_command` are ever generated — and defaults to `dry_run=True`; running for real also requires an exact confirmation phrase.
+- Every process-global cache (connection cache, testbed cache, config/learn snapshots, operation log) is protected by a lock, so concurrent HTTP clients can't corrupt shared state.
+- All credentials come from `.env` — never stored in the testbed file or source code.
 
 ---
 
@@ -211,7 +357,8 @@ docker run -i --rm \
 ```
 .
 ├── pyats_mcp_server.py      # MCP server
-├── test_pyats_mcp_server.py # Unit tests (85 tests)
+├── test_pyats_mcp_server.py # Unit tests (119 tests)
+├── benchmark/               # Pre/post, stateful/stateless transport benchmark
 ├── Dockerfile               # Container definition
 ├── requirements.txt         # Pinned runtime dependencies
 ├── requirements-dev.txt     # Dev/test dependencies
@@ -238,3 +385,17 @@ uv venv .venv && uv pip install -r requirements-dev.txt
 .venv/bin/isort .
 .venv/bin/flake8 . --max-line-length=100
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full setup and PR workflow.
+
+---
+
+## Benchmark
+
+`benchmark/` compares STDIO (legacy) against Streamable HTTP in both stateful and stateless mode, against a real testbed. See `benchmark/scenarios.py` for the scenario list and `benchmark/aggregate.py` for building the comparison report; `benchmark/results/summary.md` has the most recent run's numbers.
+
+---
+
+## License
+
+[MIT](LICENSE)

--- a/benchmark/_run_http_post.py
+++ b/benchmark/_run_http_post.py
@@ -1,0 +1,71 @@
+"""
+benchmark/_run_http_post.py
+============================
+Run under the modernized venv (.venv, mcp>=2.0.0). Connects to a running
+Streamable HTTP pyATS MCP server and times each scenario in scenarios.py.
+
+Usage:
+    .venv/bin/python benchmark/_run_http_post.py <url> <client_mode> <out.json>
+
+    <client_mode> is "auto" (negotiates the newest mutually-supported
+    protocol — SEP-2575 / 2026-07-28, handshake-free) or "legacy" (forces
+    the pre-SEP-2575 initialize-handshake protocol against the same
+    server, to isolate the protocol-version effect from the
+    stateless_http transport flag).
+"""
+import asyncio
+import json
+import sys
+import time
+
+from mcp.client.client import Client
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from scenarios import SCENARIOS, WARMUP_ITERATIONS, MEASURED_ITERATIONS  # noqa: E402
+
+
+async def time_scenario(client, tool_name, kwargs, iterations):
+    samples = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        try:
+            result = await client.call_tool(tool_name, kwargs)
+            text = result.content[0].text if result.content else "{}"
+            payload = json.loads(text)
+            ok = payload.get("status") in ("completed", "success")
+        except Exception as exc:
+            ok = False
+            payload = {"error": str(exc)}
+        elapsed = time.perf_counter() - t0
+        samples.append({"elapsed_s": elapsed, "ok": ok})
+    return samples
+
+
+async def main(url: str, mode: str, out_path: str):
+    connect_t0 = time.perf_counter()
+    async with Client(url, mode=mode) as client:
+        connect_elapsed = time.perf_counter() - connect_t0
+
+        available = {t.name for t in (await client.list_tools()).tools}
+
+        results = {}
+        for name, tool_name, kwargs in SCENARIOS:
+            if tool_name not in available:
+                results[name] = {"status": "not_available", "tool": tool_name}
+                continue
+            # warmup (discarded)
+            await time_scenario(client, tool_name, kwargs, WARMUP_ITERATIONS)
+            samples = await time_scenario(client, tool_name, kwargs, MEASURED_ITERATIONS)
+            results[name] = {"status": "measured", "tool": tool_name, "samples": samples}
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "connect_elapsed_s": connect_elapsed,
+            "url": url,
+            "client_mode": mode,
+            "results": results,
+        }, f, indent=2)
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1], sys.argv[2], sys.argv[3]))

--- a/benchmark/_run_stdio_pre.py
+++ b/benchmark/_run_stdio_pre.py
@@ -1,0 +1,76 @@
+"""
+benchmark/_run_stdio_pre.py
+=============================
+Run under the pre-modernization venv (.venv-pre, mcp==1.26.0). Spawns the
+ORIGINAL (main-branch) pyats_mcp_server.py over STDIO and times each
+scenario in scenarios.py — this is the "pre" baseline: legacy protocol,
+full initialize/session handshake, one connection for the whole run
+(STDIO has no separate connections to open per call).
+
+Usage:
+    .venv-pre/bin/python benchmark/_run_stdio_pre.py <server_py_path> <testbed_yaml_path> <out.json>
+"""
+import asyncio
+import json
+import os
+import sys
+import time
+
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from scenarios import SCENARIOS, WARMUP_ITERATIONS, MEASURED_ITERATIONS  # noqa: E402
+
+
+async def time_scenario(session, tool_name, kwargs, iterations):
+    samples = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        try:
+            result = await session.call_tool(tool_name, kwargs)
+            text = result.content[0].text if result.content else "{}"
+            payload = json.loads(text)
+            ok = payload.get("status") in ("completed", "success")
+        except Exception as exc:
+            ok = False
+            payload = {"error": str(exc)}
+        elapsed = time.perf_counter() - t0
+        samples.append({"elapsed_s": elapsed, "ok": ok})
+    return samples
+
+
+async def main(server_py: str, testbed_path: str, out_path: str):
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-u", server_py],
+        env={**os.environ, "PYATS_TESTBED_PATH": testbed_path},
+    )
+
+    connect_t0 = time.perf_counter()
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            connect_elapsed = time.perf_counter() - connect_t0
+
+            available = {t.name for t in (await session.list_tools()).tools}
+
+            results = {}
+            for name, tool_name, kwargs in SCENARIOS:
+                if tool_name not in available:
+                    results[name] = {"status": "not_available", "tool": tool_name}
+                    continue
+                await time_scenario(session, tool_name, kwargs, WARMUP_ITERATIONS)
+                samples = await time_scenario(session, tool_name, kwargs, MEASURED_ITERATIONS)
+                results[name] = {"status": "measured", "tool": tool_name, "samples": samples}
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "connect_elapsed_s": connect_elapsed,
+            "transport": "stdio",
+            "results": results,
+        }, f, indent=2)
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1], sys.argv[2], sys.argv[3]))

--- a/benchmark/aggregate.py
+++ b/benchmark/aggregate.py
@@ -1,0 +1,90 @@
+"""
+benchmark/aggregate.py
+========================
+Read the per-condition JSON result files produced by _run_stdio_pre.py /
+_run_http_post.py and render a Markdown comparison table.
+
+Usage:
+    python3 benchmark/aggregate.py <label1>=<file1.json> <label2>=<file2.json> ...
+"""
+import json
+import statistics
+import sys
+
+
+def load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def percentile(sorted_vals, pct):
+    if not sorted_vals:
+        return None
+    k = (len(sorted_vals) - 1) * pct
+    f = int(k)
+    c = min(f + 1, len(sorted_vals) - 1)
+    if f == c:
+        return sorted_vals[f]
+    return sorted_vals[f] + (sorted_vals[c] - sorted_vals[f]) * (k - f)
+
+
+def summarize(samples):
+    vals = sorted(s["elapsed_s"] for s in samples if s.get("ok"))
+    if not vals:
+        return None
+    return {
+        "n": len(vals),
+        "mean_ms": round(statistics.mean(vals) * 1000, 1),
+        "p50_ms": round(percentile(vals, 0.50) * 1000, 1),
+        "p95_ms": round(percentile(vals, 0.95) * 1000, 1),
+    }
+
+
+def main(entries):
+    conditions = {}
+    for entry in entries:
+        label, path = entry.split("=", 1)
+        conditions[label] = load(path)
+
+    scenario_names = []
+    for data in conditions.values():
+        for name in data.get("results", {}):
+            if name not in scenario_names:
+                scenario_names.append(name)
+
+    lines = []
+    lines.append("# pyATS MCP transport benchmark\n")
+    lines.append("Connection setup time per condition:\n")
+    lines.append("| condition | connect_elapsed_s |")
+    lines.append("|---|---|")
+    for label, data in conditions.items():
+        lines.append(f"| {label} | {data.get('connect_elapsed_s', 'n/a'):.4f} |")
+    lines.append("")
+
+    for scenario in scenario_names:
+        lines.append(f"## {scenario}\n")
+        lines.append("| condition | n | mean (ms) | p50 (ms) | p95 (ms) |")
+        lines.append("|---|---|---|---|---|")
+        for label, data in conditions.items():
+            entry = data.get("results", {}).get(scenario)
+            if entry is None:
+                lines.append(f"| {label} | - | not run | - | - |")
+                continue
+            if entry.get("status") == "not_available":
+                lines.append(f"| {label} | - | tool not available | - | - |")
+                continue
+            summary = summarize(entry.get("samples", []))
+            if summary is None:
+                lines.append(f"| {label} | 0 | all calls failed | - | - |")
+                continue
+            lines.append(
+                f"| {label} | {summary['n']} | {summary['mean_ms']} | "
+                f"{summary['p50_ms']} | {summary['p95_ms']} |"
+            )
+        lines.append("")
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/benchmark/results/post_legacy_stateful.json
+++ b/benchmark/results/post_legacy_stateful.json
@@ -1,0 +1,159 @@
+{
+  "connect_elapsed_s": 0.022679900000184716,
+  "url": "http://127.0.0.1:8098/mcp",
+  "client_mode": "legacy",
+  "results": {
+    "single_show_command": {
+      "status": "measured",
+      "tool": "pyats_run_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.735880969000391,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.710663476999798,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.668691482000213,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.560777006000535,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.712589285999456,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.744437491999633,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.601438184000472,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.79262923999977,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_thread_pool": {
+      "status": "measured",
+      "tool": "pyats_run_show_command_multi",
+      "samples": [
+        {
+          "elapsed_s": 15.619434729000204,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.685734296000192,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.986641202999635,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.649401048000072,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.890388222999718,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.853326383000422,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.71557699799996,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.717788987999484,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_pcall": {
+      "status": "measured",
+      "tool": "pyats_pcall_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.790600913000162,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.788438728000074,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.789600181999958,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.792548759000056,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.04115165099938,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.039068518999557,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.789361039000141,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.789480419000029,
+          "ok": true
+        }
+      ]
+    },
+    "device_health": {
+      "status": "measured",
+      "tool": "pyats_device_health",
+      "samples": [
+        {
+          "elapsed_s": 18.31510838899976,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.245451548000347,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.25605108599939,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.02466690000074,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.023924874999466,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.130755365999903,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.334656490999805,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.105562960999123,
+          "ok": true
+        }
+      ]
+    }
+  }
+}

--- a/benchmark/results/post_legacy_stateless.json
+++ b/benchmark/results/post_legacy_stateless.json
@@ -1,0 +1,159 @@
+{
+  "connect_elapsed_s": 0.02565039999990404,
+  "url": "http://127.0.0.1:8099/mcp",
+  "client_mode": "legacy",
+  "results": {
+    "single_show_command": {
+      "status": "measured",
+      "tool": "pyats_run_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.692063754000628,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.521091011999488,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.764995922000708,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.708218497999951,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.728105506999782,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.668169030999707,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.669563188999746,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.672316296000645,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_thread_pool": {
+      "status": "measured",
+      "tool": "pyats_run_show_command_multi",
+      "samples": [
+        {
+          "elapsed_s": 15.818178604999957,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.693217177000406,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.697630092000509,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.678475388999686,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.66464220600028,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.803223275000164,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.702297574000113,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.659435587999724,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_pcall": {
+      "status": "measured",
+      "tool": "pyats_pcall_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.787042992999886,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.793262492000395,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.792325190000156,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.04103769700032,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.788279761999547,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.03868679899915,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.040094401000715,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.788829123999676,
+          "ok": true
+        }
+      ]
+    },
+    "device_health": {
+      "status": "measured",
+      "tool": "pyats_device_health",
+      "samples": [
+        {
+          "elapsed_s": 18.250100670000393,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.99890256800063,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.156825013999878,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.076337438998962,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.06387461399936,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.19761282500076,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.173442887999045,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.975424764999843,
+          "ok": true
+        }
+      ]
+    }
+  }
+}

--- a/benchmark/results/post_modern_stateful.json
+++ b/benchmark/results/post_modern_stateful.json
@@ -1,0 +1,159 @@
+{
+  "connect_elapsed_s": 0.02450369899997895,
+  "url": "http://127.0.0.1:8098/mcp",
+  "client_mode": "auto",
+  "results": {
+    "single_show_command": {
+      "status": "measured",
+      "tool": "pyats_run_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.73336615000062,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.527717584999664,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.643901675000052,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.76182538500052,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.787860452000132,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.604792898999222,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.834334289999788,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.683672011999988,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_thread_pool": {
+      "status": "measured",
+      "tool": "pyats_run_show_command_multi",
+      "samples": [
+        {
+          "elapsed_s": 15.761426032999225,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.829602832999626,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.779343230999984,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.678729137000118,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.747401866000473,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.730255034000038,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.769959098999607,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.719906786000138,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_pcall": {
+      "status": "measured",
+      "tool": "pyats_pcall_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.787706033000177,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.0451497869999,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.040354281999498,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.789402910999343,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.789463010000873,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.789213672999722,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.788015189000362,
+          "ok": true
+        },
+        {
+          "elapsed_s": 16.045685236999816,
+          "ok": true
+        }
+      ]
+    },
+    "device_health": {
+      "status": "measured",
+      "tool": "pyats_device_health",
+      "samples": [
+        {
+          "elapsed_s": 18.086604019000333,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.113152807000006,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.15793639399999,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.081581776999883,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.219774172999678,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.15442976399936,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.255698410999685,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.98314689400013,
+          "ok": true
+        }
+      ]
+    }
+  }
+}

--- a/benchmark/results/pre_stdio.json
+++ b/benchmark/results/pre_stdio.json
@@ -1,0 +1,124 @@
+{
+  "connect_elapsed_s": 1.0738944029999402,
+  "transport": "stdio",
+  "results": {
+    "single_show_command": {
+      "status": "measured",
+      "tool": "pyats_run_show_command",
+      "samples": [
+        {
+          "elapsed_s": 15.704244989000472,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.580602553999597,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.74998827699983,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.618781468000634,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.783668192999357,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.836366129999988,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.600703296000574,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.651756891999867,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_thread_pool": {
+      "status": "measured",
+      "tool": "pyats_run_show_command_multi",
+      "samples": [
+        {
+          "elapsed_s": 15.709723917000701,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.668899286999476,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.721330246999969,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.667635101999622,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.876240689000042,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.737459560000389,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.839642153999193,
+          "ok": true
+        },
+        {
+          "elapsed_s": 15.904995643000802,
+          "ok": true
+        }
+      ]
+    },
+    "multi_show_pcall": {
+      "status": "not_available",
+      "tool": "pyats_pcall_show_command"
+    },
+    "device_health": {
+      "status": "measured",
+      "tool": "pyats_device_health",
+      "samples": [
+        {
+          "elapsed_s": 18.156922978000694,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.97760865300006,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.14438724899992,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.976643930000137,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.131227167999896,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.96071306199974,
+          "ok": true
+        },
+        {
+          "elapsed_s": 18.14891914600048,
+          "ok": true
+        },
+        {
+          "elapsed_s": 17.965435961000367,
+          "ok": true
+        }
+      ]
+    }
+  }
+}

--- a/benchmark/results/summary.md
+++ b/benchmark/results/summary.md
@@ -1,0 +1,47 @@
+# pyATS MCP transport benchmark
+
+Connection setup time per condition:
+
+| condition | connect_elapsed_s |
+|---|---|
+| pre_stdio (main, mcp1.26) | 1.0739 |
+| post_modern_stateful (2.0, auto/SEP-2575) | 0.0245 |
+| post_legacy_stateful (2.0, legacy proto) | 0.0227 |
+| post_legacy_stateless (2.0, legacy proto, stateless_http) | 0.0257 |
+
+## single_show_command
+
+| condition | n | mean (ms) | p50 (ms) | p95 (ms) |
+|---|---|---|---|---|
+| pre_stdio (main, mcp1.26) | 8 | 15690.8 | 15678.0 | 15817.9 |
+| post_modern_stateful (2.0, auto/SEP-2575) | 8 | 15697.2 | 15708.5 | 15818.1 |
+| post_legacy_stateful (2.0, legacy proto) | 8 | 15690.9 | 15711.6 | 15775.8 |
+| post_legacy_stateless (2.0, legacy proto, stateless_http) | 8 | 15678.1 | 15682.2 | 15752.1 |
+
+## multi_show_thread_pool
+
+| condition | n | mean (ms) | p50 (ms) | p95 (ms) |
+|---|---|---|---|---|
+| pre_stdio (main, mcp1.26) | 8 | 15765.7 | 15729.4 | 15894.9 |
+| post_modern_stateful (2.0, auto/SEP-2575) | 8 | 15752.1 | 15754.4 | 15812.0 |
+| post_legacy_stateful (2.0, legacy proto) | 8 | 15764.8 | 15716.7 | 15953.0 |
+| post_legacy_stateless (2.0, legacy proto, stateless_http) | 8 | 15714.6 | 15695.4 | 15812.9 |
+
+## multi_show_pcall
+
+| condition | n | mean (ms) | p50 (ms) | p95 (ms) |
+|---|---|---|---|---|
+| pre_stdio (main, mcp1.26) | - | tool not available | - | - |
+| post_modern_stateful (2.0, auto/SEP-2575) | 8 | 15884.4 | 15789.4 | 16045.5 |
+| post_legacy_stateful (2.0, legacy proto) | 8 | 15852.5 | 15790.1 | 16040.4 |
+| post_legacy_stateless (2.0, legacy proto, stateless_http) | 8 | 15883.7 | 15792.8 | 16040.7 |
+
+## device_health
+
+| condition | n | mean (ms) | p50 (ms) | p95 (ms) |
+|---|---|---|---|---|
+| pre_stdio (main, mcp1.26) | 8 | 18057.7 | 18054.4 | 18154.1 |
+| post_modern_stateful (2.0, auto/SEP-2575) | 8 | 18131.5 | 18133.8 | 18243.1 |
+| post_legacy_stateful (2.0, legacy proto) | 8 | 18179.5 | 18188.1 | 18327.8 |
+| post_legacy_stateless (2.0, legacy proto, stateless_http) | 8 | 18111.6 | 18116.6 | 18231.7 |
+

--- a/benchmark/scenarios.py
+++ b/benchmark/scenarios.py
@@ -1,0 +1,25 @@
+"""
+benchmark/scenarios.py
+=======================
+Shared scenario definitions for the pre/post transport benchmark.
+
+Each scenario is (name, tool_name, kwargs). Kept in one place so the
+STDIO-legacy runner and the Streamable-HTTP runner exercise identically
+shaped calls.
+"""
+
+DEVICES = ["R1", "R2", "SW1", "SW2"]
+
+SCENARIOS = [
+    ("single_show_command", "pyats_run_show_command",
+     {"device_name": "R1", "command": "show version"}),
+    ("multi_show_thread_pool", "pyats_run_show_command_multi",
+     {"device_names": DEVICES, "command": "show ip interface brief"}),
+    ("multi_show_pcall", "pyats_pcall_show_command",
+     {"device_names": DEVICES, "command": "show ip interface brief"}),
+    ("device_health", "pyats_device_health",
+     {"device_name": "R1"}),
+]
+
+WARMUP_ITERATIONS = 2
+MEASURED_ITERATIONS = 8

--- a/pyats_mcp_server.py
+++ b/pyats_mcp_server.py
@@ -3,8 +3,8 @@
 pyats_mcp_server.py
 ===================
 MCP server that exposes Cisco pyATS / Genie functionality as structured tools
-for use by AI agents (Claude, LangGraph, etc.) over STDIO using the FastMCP
-JSON-RPC 2.0 transport.
+for use by AI agents (Claude, LangGraph, etc.) over Streamable HTTP JSON-RPC 2.0
+transport, in either stateful or stateless mode (see PYATS_MCP_TRANSPORT_MODE).
 
 Design principles
 -----------------
@@ -33,15 +33,21 @@ import string
 import subprocess
 import sys
 import textwrap
+import threading
 import time
+import zipfile
 from difflib import SequenceMatcher
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+import requests
+import yaml
 from dotenv import load_dotenv
 from genie.libs.parser.utils import get_parser
-from mcp.server.fastmcp import FastMCP
+from genie.utils.diff import Diff
+from mcp.server.mcpserver import MCPServer
+from pyats.async_ import pcall
 from pyats.topology import loader
 
 # ---------------------------------------------------------------------------
@@ -73,6 +79,11 @@ ARTIFACTS_DIR: Path = Path(
 ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
 
 KEEP_ARTIFACTS: bool = os.getenv("PYATS_MCP_KEEP_ARTIFACTS", "1") == "1"
+
+# XPresso REST API — optional; pyats_xpresso_request errors clearly if unset.
+XPRESSO_URL: str = os.getenv("XPRESSO_URL", "").rstrip("/")
+XPRESSO_API_TOKEN: str = os.getenv("XPRESSO_API_TOKEN", "")
+XPRESSO_GROUP: str = os.getenv("XPRESSO_GROUP", "")
 
 # Testbed re-load interval (seconds); avoids hammering disk on every call
 def _parse_int_env(var: str, default: int) -> int:
@@ -110,6 +121,24 @@ _OP_LOG_MAX: int = _parse_int_env("PYATS_MCP_OP_LOG_MAX", 500)
 # Pre-configure snapshots for rollback  { device_name -> running-config string }
 _config_snapshots: Dict[str, str] = {}
 
+# Genie "learn" snapshots for diffing  { "device:feature:label" -> learned dict }
+_learn_snapshots: Dict[str, Dict[str, Any]] = {}
+
+# ---------------------------------------------------------------------------
+# Concurrency
+#
+# Under the STDIO transport, tool calls from one client were the only source
+# of concurrency (multi-device fan-out via asyncio.gather). Under Streamable
+# HTTP — stateful or stateless — multiple clients can hit this process at
+# once, so every mutation of the process-global caches above (_testbed_cache,
+# _conn_cache, _config_snapshots, _learn_snapshots, _OP_LOG) must be
+# serialized. Blocking device I/O (connect/disconnect/execute) must NEVER
+# happen while holding this lock — only the dict reads/writes around it —
+# otherwise concurrent device fan-out would be serialized server-wide,
+# defeating the point of the thread pool.
+# ---------------------------------------------------------------------------
+_STATE_LOCK = threading.Lock()
+
 # ---------------------------------------------------------------------------
 # ANSI / non-printable stripping
 # ---------------------------------------------------------------------------
@@ -143,9 +172,10 @@ def _log_op(
     }
     if error:
         entry["error"] = error
-    _OP_LOG.append(entry)
-    if len(_OP_LOG) > _OP_LOG_MAX:
-        _OP_LOG.pop(0)
+    with _STATE_LOCK:
+        _OP_LOG.append(entry)
+        if len(_OP_LOG) > _OP_LOG_MAX:
+            _OP_LOG.pop(0)
 
 
 def _err(
@@ -180,11 +210,12 @@ def _err(
 
 def _load_testbed():
     """Return the cached testbed, reloading from disk when the TTL has expired."""
-    now = time.time()
-    if _testbed_cache["tb"] is None or (now - _testbed_cache["loaded_at"]) > _TESTBED_CACHE_TTL:
-        _testbed_cache["tb"] = loader.load(TESTBED_PATH)
-        _testbed_cache["loaded_at"] = now
-    return _testbed_cache["tb"]
+    with _STATE_LOCK:
+        now = time.time()
+        if _testbed_cache["tb"] is None or (now - _testbed_cache["loaded_at"]) > _TESTBED_CACHE_TTL:
+            _testbed_cache["tb"] = loader.load(TESTBED_PATH)
+            _testbed_cache["loaded_at"] = now
+        return _testbed_cache["tb"]
 
 
 def _get_testbed_connection_args(device) -> Dict[str, Any]:
@@ -237,19 +268,23 @@ def _evict_expired_connections() -> None:
     if _CONN_CACHE_TTL <= 0:
         return
     now = time.time()
-    expired = [
-        k for k, v in _conn_cache.items()
-        if (now - float(v.get("last_used", 0))) > _CONN_CACHE_TTL
-    ]
-    for name in expired:
-        dev = _conn_cache.get(name, {}).get("device")
+    # Snapshot-and-pop under the lock so a concurrent _get_device() call for
+    # the same device never observes a half-evicted entry; the actual
+    # dev.disconnect() I/O then happens outside the lock.
+    with _STATE_LOCK:
+        expired = [
+            k for k, v in _conn_cache.items()
+            if (now - float(v.get("last_used", 0))) > _CONN_CACHE_TTL
+        ]
+        expired_entries = [(k, _conn_cache.pop(k, None)) for k in expired]
+    for name, entry in expired_entries:
+        dev = (entry or {}).get("device")
         try:
             if dev and getattr(dev, "is_connected", lambda: False)():
                 logger.info("Connection cache TTL expired — disconnecting %s", name)
                 dev.disconnect()
         except Exception as e:
             logger.warning("Error disconnecting expired connection for %s: %s", name, e)
-        _conn_cache.pop(name, None)
 
 
 def _get_device(device_name: str):
@@ -278,10 +313,11 @@ def _get_device(device_name: str):
 
     if _CONN_CACHE_TTL > 0:
         _evict_expired_connections()
-        cached = _conn_cache.get(device_name, {}).get("device")
-        if cached and getattr(cached, "is_connected", lambda: False)():
-            _conn_cache[device_name]["last_used"] = time.time()
-            return cached
+        with _STATE_LOCK:
+            cached = _conn_cache.get(device_name, {}).get("device")
+            if cached and getattr(cached, "is_connected", lambda: False)():
+                _conn_cache[device_name]["last_used"] = time.time()
+                return cached
 
     if not device.is_connected():
         logger.info("Connecting to %s …", device_name)
@@ -309,7 +345,8 @@ def _get_device(device_name: str):
         logger.info("Connected to %s", device_name)
 
     if _CONN_CACHE_TTL > 0:
-        _conn_cache[device_name] = {"device": device, "last_used": time.time()}
+        with _STATE_LOCK:
+            _conn_cache[device_name] = {"device": device, "last_used": time.time()}
 
     return device
 
@@ -324,10 +361,10 @@ def _disconnect_device(device, force: bool = False) -> None:
     if not device:
         return
     if _CONN_CACHE_TTL > 0 and not force:
-        try:
-            _conn_cache[getattr(device, "name", "")]["last_used"] = time.time()
-        except KeyError:
-            pass
+        with _STATE_LOCK:
+            entry = _conn_cache.get(getattr(device, "name", ""))
+            if entry is not None:
+                entry["last_used"] = time.time()
         return
     if getattr(device, "is_connected", lambda: False)():
         try:
@@ -563,6 +600,32 @@ def _execute_health(device_name: str) -> Dict[str, Any]:
         _disconnect_device(device)
 
 
+def _execute_learn_feature(device_name: str, feature: str) -> Dict[str, Any]:
+    """
+    Run Genie's device.learn(feature) and return the learned Ops data.
+
+    Unlike pyats_run_show_command's per-command parsing, device.learn()
+    gathers and normalizes everything Genie knows about one feature (e.g.
+    'interface', 'ospf', 'bgp') across whatever show commands that feature's
+    Ops model needs, vendor-neutrally.
+    """
+    device = None
+    try:
+        device = _get_device(device_name)
+        ops = device.learn(feature)
+        learned = getattr(ops, "info", None)
+        if learned is None:
+            learned = {k: v for k, v in vars(ops).items() if not k.startswith("_")}
+        return {
+            "status": "completed", "device": device_name, "feature": feature,
+            "learned": learned,
+        }
+    except Exception as exc:
+        return {"status": "error", "device": device_name, "feature": feature, "error": str(exc)}
+    finally:
+        _disconnect_device(device)
+
+
 def _execute_get_neighbors(device_name: str) -> Dict[str, Any]:
     """
     Return a clean adjacency list from CDP or LLDP neighbor tables.
@@ -712,7 +775,8 @@ async def _apply_config_with_diff(
         )
 
     if save_snapshot:
-        _config_snapshots[device_name] = before
+        with _STATE_LOCK:
+            _config_snapshots[device_name] = before
 
     result = await apply_device_configuration_async(device_name, config_commands)
     if result.get("status") == "error":
@@ -776,6 +840,32 @@ def _extract_overall_result(stdout: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
+_ARCHIVE_LINE_RE = re.compile(r"Archive\s*:\s*(\S+\.zip)")
+
+
+def _extract_job_report(stdout: str) -> Dict[str, Any]:
+    """
+    Read the structured results.json out of the job's own archive zip.
+
+    There is no working `--json-job <path>` flag in this pyATS version —
+    it is silently accepted by the CLI's argument parser but never
+    produces a report file (verified). pyATS does, however, always
+    archive the run to a .zip under ~/.pyats/archive/ by default, and
+    that archive contains a real results.json — this reads that instead.
+    """
+    match = _ARCHIVE_LINE_RE.search(stdout or "")
+    if not match:
+        return {"report": None, "archive_path": None}
+    archive_path = match.group(1)
+    try:
+        with zipfile.ZipFile(archive_path) as zf:
+            report = json.loads(zf.read("results.json"))
+        return {"report": report, "archive_path": archive_path}
+    except Exception as exc:
+        logger.warning("Could not read results.json from archive %s: %s", archive_path, exc)
+        return {"report": None, "archive_path": archive_path}
+
+
 def _run_test_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any]:
     """
     Write *script_content* to a temp directory, run it as a pyATS job, and
@@ -787,7 +877,6 @@ def _run_test_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any
 
     script_path = run_dir / "testscript.py"
     job_path = run_dir / "job.py"
-    report_path = run_dir / "job_report.json"
 
     try:
         script_path.write_text(script_content, encoding="utf-8")
@@ -798,8 +887,7 @@ def _run_test_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any
             encoding="utf-8",
         )
 
-        cmd = [shutil.which("pyats") or "pyats", "run", "job",
-               str(job_path), "--json-job", str(report_path)]
+        cmd = [shutil.which("pyats") or "pyats", "run", "job", str(job_path)]
         try:
             proc = subprocess.run(
                 cmd, capture_output=True, text=True,
@@ -811,13 +899,7 @@ def _run_test_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any
                     "error": f"pyATS job timed out after {timeout_s}s",
                     "artifacts_dir": str(run_dir)}
 
-        report = None
-        if report_path.exists():
-            try:
-                raw = report_path.read_text(encoding="utf-8")
-                report = json.loads(raw) if raw.strip() else None
-            except Exception as exc:
-                logger.warning("Could not parse job report JSON: %s", exc)
+        report_info = _extract_job_report(proc.stdout)
 
         payload = {
             "status": "completed",
@@ -825,9 +907,12 @@ def _run_test_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any
             "overall_result": _extract_overall_result(proc.stdout),
             "stdout": proc.stdout,
             "stderr": proc.stderr,
-            "report": report,
+            "report": report_info["report"],
             "artifacts_dir": str(run_dir),
-            "paths": {"script": str(script_path), "job": str(job_path), "report": str(report_path)},
+            "paths": {
+                "script": str(script_path), "job": str(job_path),
+                "archive": report_info["archive_path"],
+            },
         }
         if not KEEP_ARTIFACTS:
             shutil.rmtree(run_dir, ignore_errors=True)
@@ -840,7 +925,7 @@ def _run_test_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any
 # ---------------------------------------------------------------------------
 # MCP server instance
 # ---------------------------------------------------------------------------
-mcp = FastMCP("pyATS Network Automation Server")
+mcp = MCPServer("pyATS Network Automation Server")
 
 
 # ===========================================================================
@@ -1066,6 +1151,78 @@ async def pyats_run_show_command_multi(device_names: List[str], command: str) ->
         return json.dumps(_err("pyats_run_show_command_multi", None, command, str(exc)), indent=2)
 
 
+def _pcall_show_command(device_names: List[str], command: str) -> List[Dict[str, Any]]:
+    """
+    Run _execute_show_raw once per device, each in its own forked OS process
+    via pyats.async_.pcall — a process-isolated alternative to the thread
+    pool used by pyats_run_show_command_multi.
+
+    Each child process is a fork() of this one, so it starts with its own
+    private copy of _testbed_cache / _conn_cache / _STATE_LOCK (fork gives
+    every child independent memory — nothing it does propagates back to the
+    parent). It always connects and disconnects fresh; it never reuses a
+    connection from the parent's _conn_cache. Prefer this over the
+    thread-pool version for very large device counts where true OS-level
+    isolation (one process crashing can't affect another) matters more than
+    the extra fork overhead.
+    """
+    results = pcall(_execute_show_raw, iargs=[(name, command) for name in device_names])
+    return list(results)
+
+
+@mcp.tool()
+async def pyats_pcall_show_command(device_names: List[str], command: str) -> str:
+    """
+    Run ONE show command across MULTIPLE devices, each in its own OS process
+    (pyats.async_.pcall) rather than a shared thread pool.
+
+    WHEN TO USE:
+      Prefer pyats_run_show_command_multi for everyday fan-out — it has far
+      less overhead. Reach for this tool instead when you specifically want
+      process-level isolation across a large device count (e.g. a parser
+      crash or a runaway command on one device cannot affect any other,
+      since each device runs in its own forked process, not a shared
+      thread pool).
+
+    Args:
+        device_names: List of exact device names.
+        command:      Show command to run on every device (same rules as
+                      pyats_run_show_command — must start with 'show').
+
+    Returns:
+        {
+          "status": "completed",
+          "command": "show ip bgp summary",
+          "concurrency": "pcall (process per device)",
+          "summary": {"total": 3, "success": 2, "failed": 1},
+          "results": [ {per-device result}, ... ]
+        }
+    """
+    if not device_names:
+        return json.dumps(_err("pyats_pcall_show_command", None, command,
+                               "device_names is empty.",
+                               "Call pyats_list_devices to get valid names."), indent=2)
+    err = validate_show_command(command)
+    if err:
+        return json.dumps(_err("pyats_pcall_show_command", None, command, err), indent=2)
+
+    try:
+        results: List[Dict[str, Any]] = await _run_in_executor(_pcall_show_command, device_names, command)
+        success = sum(1 for r in results if r.get("status") == "completed")
+        for r in results:
+            _log_op("pyats_pcall_show_command", r.get("device"), command,
+                    r.get("status", "error"), r.get("error"))
+        return json.dumps({
+            "status": "completed", "command": command,
+            "concurrency": "pcall (process per device)",
+            "summary": {"total": len(results), "success": success, "failed": len(results) - success},
+            "results": results,
+        }, indent=2)
+    except Exception as exc:
+        logger.error("pyats_pcall_show_command failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_pcall_show_command", None, command, str(exc)), indent=2)
+
+
 @mcp.tool()
 async def pyats_show_running_config(device_name: str) -> str:
     """
@@ -1173,6 +1330,104 @@ async def pyats_device_health(device_name: str) -> str:
     except Exception as exc:
         logger.error("pyats_device_health failed: %s", exc, exc_info=True)
         return json.dumps(_err("pyats_device_health", device_name, None, str(exc)), indent=2)
+
+
+@mcp.tool()
+async def pyats_learn_feature(
+    device_name: str,
+    feature: str,
+    snapshot_label: Optional[str] = None,
+) -> str:
+    """
+    Run Genie's device.learn(feature) and optionally save the result as a
+    named snapshot for later comparison with pyats_diff_learned_snapshots.
+
+    WHEN TO USE:
+      Use for a vendor-neutral, structured view of an entire feature (e.g.
+      'interface', 'ospf', 'bgp', 'routing', 'platform') rather than parsing
+      individual show commands one at a time. Also the first half of a
+      before/after comparison — call once before a change with
+      snapshot_label="before", again after with snapshot_label="after",
+      then pyats_diff_learned_snapshots("before", "after").
+
+    Args:
+        device_name:    Exact device name.
+        feature:        Genie feature name (e.g. "interface", "ospf", "bgp").
+        snapshot_label: If given, store this learn result under this label
+                        for this device+feature so it can be diffed later.
+                        Labels are process-global and overwrite any prior
+                        snapshot with the same device+feature+label.
+
+    Returns:
+        { "status": "completed", "device": "...", "feature": "ospf",
+          "learned": {...}, "snapshot_saved": "before" }
+    """
+    try:
+        result = await _run_in_executor(_execute_learn_feature, device_name, feature)
+        if result.get("status") == "completed" and snapshot_label:
+            with _STATE_LOCK:
+                _learn_snapshots[f"{device_name}:{feature}:{snapshot_label}"] = result["learned"]
+            result["snapshot_saved"] = snapshot_label
+        _log_op("pyats_learn_feature", device_name, feature,
+                result.get("status", "error"), result.get("error"))
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.error("pyats_learn_feature failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_learn_feature", device_name, feature, str(exc)), indent=2)
+
+
+@mcp.tool()
+async def pyats_diff_learned_snapshots(
+    device_name: str,
+    feature: str,
+    label_a: str,
+    label_b: str,
+) -> str:
+    """
+    Compare two previously saved pyats_learn_feature snapshots for one
+    device+feature and return a unified diff.
+
+    PRECONDITION:
+      Both snapshots must already exist — call pyats_learn_feature twice
+      first, once per label, for the same device_name and feature.
+
+    Args:
+        device_name: Exact device name.
+        feature:     Genie feature name — must match what was learned.
+        label_a:     Label of the "before" snapshot.
+        label_b:     Label of the "after" snapshot.
+
+    Returns:
+        { "status": "completed", "device": "...", "feature": "ospf",
+          "diff": "  neighbors:\\n-  10.0.0.1: up\\n+  10.0.0.1: down" }
+      diff is empty string if the two snapshots are identical.
+    """
+    key_a = f"{device_name}:{feature}:{label_a}"
+    key_b = f"{device_name}:{feature}:{label_b}"
+    with _STATE_LOCK:
+        snap_a = _learn_snapshots.get(key_a)
+        snap_b = _learn_snapshots.get(key_b)
+
+    missing = [lbl for lbl, snap in ((label_a, snap_a), (label_b, snap_b)) if snap is None]
+    if missing:
+        return json.dumps(_err(
+            "pyats_diff_learned_snapshots", device_name, feature,
+            f"No snapshot found for label(s): {', '.join(missing)}.",
+            "Call pyats_learn_feature with snapshot_label set for each label first.",
+        ), indent=2)
+
+    try:
+        diff = Diff(snap_a, snap_b)
+        diff.findDiff()
+        diff_text = str(diff)
+        _log_op("pyats_diff_learned_snapshots", device_name, f"{feature}:{label_a}->{label_b}", "completed")
+        return json.dumps({
+            "status": "completed", "device": device_name, "feature": feature,
+            "label_a": label_a, "label_b": label_b, "diff": diff_text,
+        }, indent=2)
+    except Exception as exc:
+        logger.error("pyats_diff_learned_snapshots failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_diff_learned_snapshots", device_name, feature, str(exc)), indent=2)
 
 
 @mcp.tool()
@@ -1486,15 +1741,16 @@ async def pyats_rollback_config(device_name: str) -> str:
     AFTER ROLLBACK:
       Confirm success with pyats_show_running_config or pyats_device_health.
     """
-    if device_name not in _config_snapshots:
+    with _STATE_LOCK:
+        snapshot = _config_snapshots.get(device_name)
+
+    if snapshot is None:
         return json.dumps(_err(
             "pyats_rollback_config", device_name, None,
             f"No rollback snapshot found for '{device_name}'.",
             "Snapshots are saved automatically by pyats_configure_with_diff. "
             "If you used pyats_configure_device no snapshot was created.",
         ), indent=2)
-
-    snapshot = _config_snapshots[device_name]
     # Strip comment lines before re-applying
     lines = [l for l in snapshot.splitlines() if l.strip() and not l.strip().startswith("!")]
 
@@ -1568,6 +1824,370 @@ async def pyats_configure_devices_multi(
         return json.dumps(_err("pyats_configure_devices_multi", None, None, str(exc)), indent=2)
 
 
+def _pcall_configure_devices(device_names: List[str], config_commands: Any) -> List[Dict[str, Any]]:
+    """Process-isolated sibling of pyats_configure_devices_multi — see _pcall_show_command."""
+    results = pcall(_execute_config, iargs=[(name, config_commands) for name in device_names])
+    return list(results)
+
+
+@mcp.tool()
+async def pyats_pcall_configure_devices(
+    device_names: List[str],
+    config_commands: Any,
+) -> str:
+    """
+    Push the SAME configuration to MULTIPLE devices, each in its own OS
+    process (pyats.async_.pcall) rather than a shared thread pool.
+
+    WHEN TO USE:
+      Same use case as pyats_configure_devices_multi (uniform fleet-wide
+      config push) — reach for this variant instead when you want process-
+      level isolation across a large device count, at the cost of fork
+      overhead per device. Guardrails (_config_guardrails) still apply
+      identically inside each child process.
+
+    Args:
+        device_names:    List of exact device names.
+        config_commands: Config payload applied identically to all devices.
+                         Same format rules as pyats_configure_device.
+
+    Returns:
+        {
+          "status": "completed",
+          "concurrency": "pcall (process per device)",
+          "summary": {"total": 3, "success": 2, "failed": 1},
+          "results": [ {per-device result}, ... ]
+        }
+    """
+    if not device_names:
+        return json.dumps(_err("pyats_pcall_configure_devices", None, None,
+                               "device_names is empty.",
+                               "Call pyats_list_devices to get valid names."), indent=2)
+    try:
+        results: List[Dict[str, Any]] = await _run_in_executor(
+            _pcall_configure_devices, device_names, config_commands
+        )
+        success = sum(1 for r in results if r.get("status") == "success")
+        for r in results:
+            _log_op("pyats_pcall_configure_devices", r.get("device"),
+                    str(config_commands)[:80], r.get("status", "error"), r.get("error"))
+        return json.dumps({
+            "status": "completed",
+            "concurrency": "pcall (process per device)",
+            "summary": {"total": len(results), "success": success, "failed": len(results) - success},
+            "results": results,
+        }, indent=2)
+    except Exception as exc:
+        logger.error("pyats_pcall_configure_devices failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_pcall_configure_devices", None, None, str(exc)), indent=2)
+
+
+# ===========================================================================
+# REST / RESTCONF TOOL
+#
+# Separate from the CLI/SSH tools above — uses pyATS's rest.connector.Rest
+# instead of Unicon. Requires the testbed device to define its own 'rest'
+# connection block (class: rest.connector.Rest); does NOT reuse _get_device
+# / _conn_cache, which are Unicon/CLI-specific. RESTCONF's connect() is a
+# no-op per the connector's own docs (no real handshake), so there is no
+# connection-caching complexity to add here — each call just reuses
+# device.rest's underlying requests.Session if already connected, or
+# connects once on first use.
+# ===========================================================================
+_REST_METHODS: frozenset = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE"})
+
+
+def _get_rest_device(device_name: str):
+    """Return device.rest, connecting via the testbed's 'rest' alias if needed."""
+    tb = _load_testbed()
+    device = tb.devices.get(device_name)
+    if not device:
+        raise ValueError(
+            f"Device '{device_name}' not found in testbed. "
+            "Use pyats_list_devices or pyats_search_devices to find valid names."
+        )
+    connections = getattr(device, "connections", {}) or {}
+    if "rest" not in connections:
+        raise ValueError(
+            f"Device '{device_name}' has no 'rest' connection block in the testbed. "
+            "Add connections.rest with class: rest.connector.Rest (see README)."
+        )
+    conn = getattr(device, "rest", None)
+    if conn is None or not getattr(conn, "connected", False):
+        device.connect(alias="rest", via="rest")
+    return device.rest
+
+
+def _execute_rest_request(
+    device_name: str,
+    method: str,
+    api_url: str,
+    payload: Optional[str] = None,
+    content_type: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 30,
+) -> Dict[str, Any]:
+    method_u = (method or "").upper()
+    if method_u not in _REST_METHODS:
+        return {"status": "error", "device": device_name, "method": method, "api_url": api_url,
+                "error": f"Unsupported method '{method}'. Use one of {sorted(_REST_METHODS)}."}
+    try:
+        rest = _get_rest_device(device_name)
+        kwargs: Dict[str, Any] = {"timeout": timeout}
+        if content_type:
+            kwargs["content_type"] = content_type
+        if headers:
+            kwargs["headers"] = headers
+
+        if method_u == "GET":
+            resp = rest.get(api_url, **kwargs)
+        elif method_u == "DELETE":
+            resp = rest.delete(api_url, **kwargs)
+        else:
+            fn = {"POST": rest.post, "PUT": rest.put, "PATCH": rest.patch}[method_u]
+            resp = fn(api_url, payload=payload or "", **kwargs)
+
+        body_text = resp.text
+        try:
+            body: Any = json.loads(body_text) if body_text else None
+        except ValueError:
+            body = body_text
+
+        return {
+            "status": "completed", "device": device_name, "method": method_u, "api_url": api_url,
+            "status_code": resp.status_code, "body": body,
+        }
+    except Exception as exc:
+        return {"status": "error", "device": device_name, "method": method_u, "api_url": api_url,
+                "error": str(exc)}
+
+
+@mcp.tool()
+async def pyats_rest_request(
+    device_name: str,
+    method: str,
+    api_url: str,
+    payload: Optional[str] = None,
+    content_type: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 30,
+) -> str:
+    """
+    Make a generic REST/RESTCONF API call against a device using pyATS's
+    REST connector, for devices or controllers better automated over a
+    REST API than the CLI (RESTCONF on IOS-XE, NX-API on NX-OS, or any
+    other generic JSON/XML REST endpoint pyATS's rest.connector supports).
+
+    PRECONDITION:
+      The device's testbed entry must define a 'rest' connection block:
+        connections:
+          rest:
+            class: rest.connector.Rest
+            ip: <address>
+            port: "443"
+            protocol: https
+            credentials:
+              rest:
+                username: ...
+                password: ...
+
+    Args:
+        device_name:  Exact device name (must have a 'rest' connection block).
+        method:       One of GET, POST, PUT, PATCH, DELETE.
+        api_url:      Path portion of the URL, e.g.
+                      "/restconf/data/ietf-interfaces:interfaces".
+        payload:      JSON/XML body string for POST/PUT/PATCH (ignored for
+                      GET/DELETE).
+        content_type: "json" or "xml" (defaults to the connector's default).
+        headers:      Extra HTTP headers as a dict.
+        timeout:      Request timeout in seconds (default 30).
+
+    Returns:
+        { "status": "completed", "device": "...", "method": "GET",
+          "api_url": "...", "status_code": 200, "body": {...} }
+    """
+    if not (device_name or "").strip():
+        return json.dumps(_err("pyats_rest_request", device_name, api_url, "device_name is empty."), indent=2)
+    if not (api_url or "").strip():
+        return json.dumps(_err("pyats_rest_request", device_name, api_url, "api_url is empty."), indent=2)
+    try:
+        result = await _run_in_executor(
+            _execute_rest_request, device_name, method, api_url, payload, content_type, headers, timeout
+        )
+        _log_op("pyats_rest_request", device_name, f"{method} {api_url}",
+                result.get("status", "error"), result.get("error"))
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.error("pyats_rest_request failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_rest_request", device_name, api_url, str(exc)), indent=2)
+
+
+# ===========================================================================
+# DEVICE CLEAN TOOL (Genie / Kleenex)
+#
+# Genie's clean/Kleenex engine has no supported public in-process API — the
+# DeviceClean class is an internal implementation detail tightly coupled to
+# pyats.aetest's global executer state, normally driven only by the `pyats
+# clean` CLI. That CLI *is* a fully supported entry point, so this tool
+# shells out to it (subprocess, timeout-bounded) rather than reaching into
+# genie.libs.clean internals directly.
+#
+# Genie's real clean stage catalog (ChangeBootVariable, Reload, WriteErase,
+# InstallImage, CopyToDevice, ...) is inherently destructive — that is the
+# point of "clean" (staged device reset/reprovisioning). This tool does not
+# expose those stages. It only ever generates a clean.yaml with the
+# 'connect' and 'execute_command' stages (schema confirmed against the
+# installed genie.libs.clean package's own test fixtures), so the worst
+# this tool can do is run read/exec-style commands on the device through
+# the clean framework — the same commands are still screened by
+# _config_guardrails. dry_run defaults to True, and running for real
+# requires an explicit literal confirm string.
+# ===========================================================================
+_CLEAN_CONFIRM_PHRASE = "I UNDERSTAND THIS IS A REAL DEVICE OPERATION"
+
+
+def _build_clean_yaml(device_name: str, commands: List[str]) -> str:
+    """Build a minimal, non-destructive clean.yaml (connect + execute_command only)."""
+    doc = {
+        "cleaners": {
+            "DeviceClean": {
+                "module": "genie.libs.clean",
+                "devices": [device_name],
+            },
+        },
+        "devices": {
+            device_name: {
+                "connect": None,
+                "execute_command": {"commands": commands},
+                "order": ["connect", "execute_command"],
+            },
+        },
+    }
+    return yaml.safe_dump(doc, sort_keys=False)
+
+
+def _execute_clean_device(
+    device_name: str, commands: List[str], timeout_s: int = 300
+) -> Dict[str, Any]:
+    """Write the generated clean.yaml and run `pyats clean` against it."""
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    run_dir = ARTIFACTS_DIR / f"clean_{ts}_{os.getpid()}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    clean_path = run_dir / "clean.yaml"
+
+    try:
+        clean_yaml = _build_clean_yaml(device_name, commands)
+        clean_path.write_text(clean_yaml, encoding="utf-8")
+
+        cmd = [
+            shutil.which("pyats") or "pyats", "clean",
+            "--testbed-file", TESTBED_PATH,
+            "--clean-file", str(clean_path),
+            "--clean-devices", device_name,
+            "--no-mail",
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            return {"status": "error", "device": device_name,
+                    "error": f"pyats clean timed out after {timeout_s}s",
+                    "clean_yaml": clean_yaml, "artifacts_dir": str(run_dir)}
+
+        payload = {
+            "status": "completed" if proc.returncode == 0 else "error",
+            "device": device_name,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "clean_yaml": clean_yaml,
+            "artifacts_dir": str(run_dir),
+        }
+        if proc.returncode != 0:
+            payload["error"] = f"pyats clean exited with code {proc.returncode}"
+        if not KEEP_ARTIFACTS:
+            shutil.rmtree(run_dir, ignore_errors=True)
+        return payload
+    except Exception as exc:
+        logger.error("_execute_clean_device failed: %s", exc, exc_info=True)
+        return {"status": "error", "device": device_name, "error": str(exc), "artifacts_dir": str(run_dir)}
+
+
+@mcp.tool()
+async def pyats_clean_device(
+    device_name: str,
+    commands: List[str],
+    dry_run: bool = True,
+    confirm: Optional[str] = None,
+) -> str:
+    """
+    Run a conservative Genie Clean (Kleenex) stage sequence against a device:
+    connect, then execute a list of commands. Real Genie clean stages that
+    reboot, erase, or reimage a device are NOT exposed by this tool — only
+    'connect' + 'execute_command' are ever generated.
+
+    WHEN TO USE:
+      Use to validate the Genie clean/Kleenex pipeline itself (testbed
+      wiring, clean-file schema, CLI invocation) against a real device
+      without risking a reload or config wipe — e.g. as a smoke test before
+      trusting clean in a bigger workflow, or to run a batch of commands
+      through the clean framework specifically (as opposed to
+      pyats_run_show_command, which does not use Kleenex at all).
+
+    SAFETY:
+      - dry_run=True (default): returns the generated clean.yaml and does
+        NOT touch the device or spawn any subprocess.
+      - dry_run=False: requires confirm to exactly equal
+        "I UNDERSTAND THIS IS A REAL DEVICE OPERATION", then shells out to
+        `pyats clean` for real. Commands are still screened by the same
+        guardrails as pyats_configure_device (reload/erase/delete/format
+        are blocked).
+
+    Args:
+        device_name: Exact device name.
+        commands:    List of commands to run via the clean execute_command
+                     stage (e.g. ["show version", "show boot"]).
+        dry_run:     If True (default), only generate and return the
+                     clean.yaml — no device contact.
+        confirm:     Required literal string when dry_run=False:
+                     "I UNDERSTAND THIS IS A REAL DEVICE OPERATION"
+
+    Returns:
+        { "status": "completed", "device": "...", "returncode": 0,
+          "stdout": "...", "clean_yaml": "...", "artifacts_dir": "..." }
+    """
+    if not commands:
+        return json.dumps(_err("pyats_clean_device", device_name, None,
+                               "commands is empty."), indent=2)
+    guard = _config_guardrails(commands)
+    if guard:
+        return json.dumps(_err("pyats_clean_device", device_name, None, guard), indent=2)
+
+    if dry_run:
+        clean_yaml = _build_clean_yaml(device_name, commands)
+        _log_op("pyats_clean_device", device_name, "dry_run", "completed")
+        return json.dumps({
+            "status": "completed", "device": device_name, "dry_run": True,
+            "clean_yaml": clean_yaml,
+            "message": "Dry run only — no subprocess spawned, device not contacted.",
+        }, indent=2)
+
+    if confirm != _CLEAN_CONFIRM_PHRASE:
+        return json.dumps(_err(
+            "pyats_clean_device", device_name, None,
+            "confirm did not match the required phrase.",
+            f"Pass confirm=\"{_CLEAN_CONFIRM_PHRASE}\" to run for real, or leave dry_run=True.",
+        ), indent=2)
+
+    try:
+        result = await _run_in_executor(_execute_clean_device, device_name, commands, 300)
+        _log_op("pyats_clean_device", device_name, "clean_execute_command",
+                result.get("status", "error"), result.get("error"))
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.error("pyats_clean_device failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_clean_device", device_name, None, str(exc)), indent=2)
+
+
 # ===========================================================================
 # TESTING TOOL
 # ===========================================================================
@@ -1616,6 +2236,413 @@ async def pyats_run_dynamic_test(test_script_content: str) -> str:
 
 
 # ===========================================================================
+# DECLARATIVE TEST TOOL (pyATS Blitz)
+#
+# Blitz (genie.libs.sdk.triggers.blitz.blitz.Blitz) has no supported
+# in-process API — its class imports the global pyats.easypy.runtime
+# singleton, so like Genie clean it must run inside a real job/easypy
+# runner. This tool generates a trigger datafile + job file and shells out
+# to `pyats run job`, the same subprocess-with-timeout shape as
+# pyats_run_dynamic_test/_run_test_script above — including the structured
+# report, read via _extract_job_report() from the job's own archive zip
+# rather than the CLI's `--json-job` flag (verified dead: silently
+# accepted, never produces a report file in this pyATS version).
+# ===========================================================================
+_BLITZ_TRIGGER_NAME = "PyatsMcpBlitz"
+
+
+def _blitz_guardrails(actions_yaml: str) -> Optional[str]:
+    """Best-effort denylist scan over raw blitz YAML text, same spirit as _config_guardrails."""
+    lowered = (actions_yaml or "").lower()
+    dangerous = [
+        (r"\bwrite\s+erase\b", "write erase"),
+        (r"\breload\b", "reload"),
+        (r"\berase\b", "erase"),
+        (r"\bformat\b", "format"),
+    ]
+    for pattern, label in dangerous:
+        if re.search(pattern, lowered, flags=re.MULTILINE):
+            return f"Dangerous command detected in blitz actions: '{label}'. Operation aborted."
+    return None
+
+
+def _build_scoped_testbed(device_names: List[str], run_dir: Path) -> str:
+    """
+    Write a trimmed copy of the real testbed containing only *device_names*.
+
+    genie.harness's common_setup (used by `pyats run job`) connects to
+    EVERY device in whatever testbed it's given, not just the ones a
+    specific trigger targets — so a full-testbed run fails outright the
+    moment any device in the testbed (even one this call doesn't care
+    about) is unreachable. Scoping the testbed file itself is the fix.
+
+    Any %ENV{...} placeholders are left untouched (this is a plain YAML
+    read/filter/write, not a pyats.topology.loader.load() — substitution
+    still happens normally when the scoped file is loaded by the
+    subprocess, which inherits this process's environment).
+    """
+    with open(TESTBED_PATH, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    all_devices = raw.get("devices", {}) or {}
+    raw["devices"] = {name: all_devices[name] for name in device_names if name in all_devices}
+    scoped_path = run_dir / "scoped_testbed.yaml"
+    scoped_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return str(scoped_path)
+
+
+def _run_blitz(actions_yaml: str, device_names: List[str], timeout_s: int = 300) -> Dict[str, Any]:
+    """
+    Wrap *actions_yaml* (a YAML list matching Blitz's test_sections schema)
+    into a trigger datafile and run it via `pyats run job` + genie.harness's
+    gRun, against a testbed scoped to just *device_names*.
+    """
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    run_dir = ARTIFACTS_DIR / f"blitz_{ts}_{os.getpid()}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    trigger_path = run_dir / "trigger_datafile.yaml"
+    job_path = run_dir / "blitz_job.py"
+
+    try:
+        try:
+            sections = yaml.safe_load(actions_yaml)
+        except Exception as exc:
+            return {"status": "error", "error": f"actions_yaml is not valid YAML: {exc}",
+                    "artifacts_dir": str(run_dir)}
+        if not isinstance(sections, list):
+            return {"status": "error",
+                    "error": "actions_yaml must parse to a YAML list (Blitz test_sections).",
+                    "artifacts_dir": str(run_dir)}
+
+        trigger_doc = {
+            _BLITZ_TRIGGER_NAME: {
+                "source": {"pkg": "genie.libs.sdk", "class": "triggers.blitz.blitz.Blitz"},
+                "devices": device_names,
+                "test_sections": sections,
+            },
+        }
+        trigger_path.write_text(yaml.safe_dump(trigger_doc, sort_keys=False), encoding="utf-8")
+        job_path.write_text(
+            "from genie.harness.main import gRun\n"
+            "def main(runtime):\n"
+            f"    gRun(trigger_datafile=r'{trigger_path}', trigger_uids=['{_BLITZ_TRIGGER_NAME}'])\n",
+            encoding="utf-8",
+        )
+        scoped_testbed_path = _build_scoped_testbed(device_names, run_dir)
+
+        cmd = [shutil.which("pyats") or "pyats", "run", "job", str(job_path),
+               "--testbed-file", scoped_testbed_path, "--no-mail"]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            return {"status": "error", "error": f"blitz job timed out after {timeout_s}s",
+                    "artifacts_dir": str(run_dir)}
+
+        report_info = _extract_job_report(proc.stdout)
+        payload = {
+            "status": "completed",
+            "returncode": proc.returncode,
+            "overall_result": _extract_overall_result(proc.stdout),
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "report": report_info["report"],
+            "trigger_datafile": str(trigger_path),
+            "archive": report_info["archive_path"],
+            "artifacts_dir": str(run_dir),
+        }
+        if not KEEP_ARTIFACTS:
+            shutil.rmtree(run_dir, ignore_errors=True)
+        return payload
+    except Exception as exc:
+        logger.error("_run_blitz failed: %s", exc, exc_info=True)
+        return {"status": "error", "error": str(exc), "artifacts_dir": str(run_dir)}
+
+
+@mcp.tool()
+async def pyats_run_blitz(actions_yaml: str, device_names: List[str]) -> str:
+    """
+    Run a declarative pyATS Blitz test against one or more devices.
+
+    WHEN TO USE:
+      Multi-step, declarative device workflows (execute, configure, parse,
+      learn, and more, chained across named steps) expressed as data rather
+      than code — e.g. "run show version, then configure an ACL, then
+      verify it applied." For pure PASS/FAIL logic over already-known data
+      use pyats_run_dynamic_test instead; for one ad-hoc command use
+      pyats_run_show_command.
+
+    Args:
+        actions_yaml: YAML text for Blitz's test_sections — a list of named
+                      steps, each a list of actions. Example:
+                        - step1:
+                          - execute:
+                              device: R1
+                              command: show version
+        device_names: Devices this blitz trigger runs against (the
+                      trigger's top-level 'devices:' list).
+
+    Returns:
+        { "status": "completed", "overall_result": "PASSED|FAILED",
+          "returncode": 0, "stdout": "...", "stderr": "...",
+          "trigger_datafile": "/path/...", "artifacts_dir": "..." }
+    """
+    if not (actions_yaml or "").strip():
+        return json.dumps(_err("pyats_run_blitz", None, None, "actions_yaml is empty."), indent=2)
+    if not device_names:
+        return json.dumps(_err("pyats_run_blitz", None, None,
+                               "device_names is empty.",
+                               "Call pyats_list_devices to get valid names."), indent=2)
+    guard = _blitz_guardrails(actions_yaml)
+    if guard:
+        return json.dumps(_err("pyats_run_blitz", None, None, guard), indent=2)
+
+    try:
+        result = await _run_in_executor(_run_blitz, actions_yaml, device_names, 300)
+        _log_op("pyats_run_blitz", ",".join(device_names), "blitz",
+                result.get("status", "error"), result.get("error"))
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.error("pyats_run_blitz failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_run_blitz", None, None, str(exc)), indent=2)
+
+
+# ===========================================================================
+# ROBOT FRAMEWORK TOOL
+#
+# This pyATS version has no `pyats robot` CLI subcommand — pyats.robot and
+# genie.libs.robot are Robot Framework *libraries*, imported from inside
+# the .robot suite itself (verified installed: robotframework 7.4.2,
+# pyats.robot.pyATSRobot, genie.libs.robot.GenieRobot). So this tool runs
+# the suite via the standalone `robot` CLI (subprocess, timeout-bounded),
+# the same shape as the other external-runner tools above. Keyword syntax
+# below is confirmed against the installed libraries' @keyword decorators,
+# not guessed: 'Use Testbed "${testbed}"', 'Connect To Device "${device}"',
+# 'Parse "${parser}" on device "${device}"', 'Learn "${feature}" on device
+# "${device}"'.
+# ===========================================================================
+
+def _robot_guardrails(script: str) -> Optional[str]:
+    """Best-effort denylist scan over raw Robot script text, same spirit as _config_guardrails."""
+    lowered = (script or "").lower()
+    dangerous = [
+        (r"\bwrite\s+erase\b", "write erase"),
+        (r"\breload\b", "reload"),
+        (r"\berase\b", "erase"),
+        (r"\bformat\b", "format"),
+    ]
+    for pattern, label in dangerous:
+        if re.search(pattern, lowered, flags=re.MULTILINE):
+            return f"Dangerous command detected in robot script: '{label}'. Operation aborted."
+    return None
+
+
+def _run_robot_script(script_content: str, timeout_s: int = 300) -> Dict[str, Any]:
+    """
+    Write *script_content* to a .robot file — substituting the literal
+    token {{TESTBED_PATH}} with this server's real, absolute testbed
+    path — and run it via the `robot` CLI.
+    """
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    run_dir = ARTIFACTS_DIR / f"robot_{ts}_{os.getpid()}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    suite_path = run_dir / "suite.robot"
+
+    try:
+        rendered = script_content.replace("{{TESTBED_PATH}}", TESTBED_PATH)
+        suite_path.write_text(rendered, encoding="utf-8")
+
+        cmd = [shutil.which("robot") or "robot", "--outputdir", str(run_dir), str(suite_path)]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            return {"status": "error", "error": f"robot run timed out after {timeout_s}s",
+                    "artifacts_dir": str(run_dir)}
+
+        payload = {
+            "status": "completed",
+            "overall_result": "PASSED" if proc.returncode == 0 else "FAILED",
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "artifacts_dir": str(run_dir),
+            "paths": {
+                "suite": str(suite_path),
+                "output_xml": str(run_dir / "output.xml"),
+                "log_html": str(run_dir / "log.html"),
+                "report_html": str(run_dir / "report.html"),
+            },
+        }
+        if not KEEP_ARTIFACTS:
+            shutil.rmtree(run_dir, ignore_errors=True)
+        return payload
+    except Exception as exc:
+        logger.error("_run_robot_script failed: %s", exc, exc_info=True)
+        return {"status": "error", "error": str(exc), "artifacts_dir": str(run_dir)}
+
+
+@mcp.tool()
+async def pyats_run_robot(robot_script_content: str) -> str:
+    """
+    Run a Robot Framework test suite with pyATS/Genie keyword libraries
+    against the real testbed.
+
+    WHEN TO USE:
+      Keyword-driven, non-Python test suites — a good fit if your team
+      already standardizes on Robot Framework for authoring/reporting.
+      For Python logic use pyats_run_dynamic_test; for declarative YAML
+      actions use pyats_run_blitz.
+
+    HOW IT WORKS:
+      Writes robot_script_content to a .robot file and runs it via the
+      standalone `robot` CLI (subprocess, timeout-bounded). Example
+      suite content:
+
+        *** Settings ***
+        Library    pyats.robot.pyATSRobot
+        Library    genie.libs.robot.GenieRobot
+
+        *** Test Cases ***
+        Check Version
+            Use Testbed "{{TESTBED_PATH}}"
+            Connect To Device "R1"
+            ${result}=    Parse "show version" on device "R1"
+            Disconnect From Device "R1"
+
+      The literal token {{TESTBED_PATH}} is substituted with this
+      server's real, absolute testbed path before the suite runs — you
+      never need to know or hard-code that path yourself.
+
+      IMPORTANT — Robot's embedded-argument keywords (Use Testbed "...",
+      Connect To Device "...", Parse "..." on device "...", etc.) must
+      have exactly ONE space before each quoted part, not the usual
+      multi-space/tab column separator — extra spaces make Robot split
+      it into a bogus multi-cell call and fail with "No keyword with
+      name '...' found" (verified against the installed library).
+
+    Args:
+        robot_script_content: Complete .robot suite text (Settings +
+                              Test Cases sections).
+
+    Returns:
+        { "status": "completed", "overall_result": "PASSED|FAILED",
+          "returncode": 0, "stdout": "...", "stderr": "...",
+          "artifacts_dir": "...", "paths": {"output_xml": "...", ...} }
+    """
+    if not (robot_script_content or "").strip():
+        return json.dumps(_err("pyats_run_robot", None, None, "robot_script_content is empty."), indent=2)
+    guard = _robot_guardrails(robot_script_content)
+    if guard:
+        return json.dumps(_err("pyats_run_robot", None, None, guard), indent=2)
+    try:
+        result = await _run_in_executor(_run_robot_script, robot_script_content, 300)
+        _log_op("pyats_run_robot", None, "robot_suite",
+                result.get("status", "error"), result.get("error"))
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.error("pyats_run_robot failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_run_robot", None, None, str(exc)), indent=2)
+
+
+# ===========================================================================
+# XPRESSO REST API TOOL
+#
+# CAUTION — UNVERIFIED: built directly from Cisco's published XPresso REST
+# API v2 documentation (Authorization: Jwt <token> + Group: <name> headers,
+# offset/limit pagination), but not exercised against a live XPresso
+# instance — none was available while writing this tool. Treat the first
+# real call against your XPresso server as the actual verification step,
+# and expect to adjust header/path details if your instance's behavior
+# differs from the published docs.
+# ===========================================================================
+
+_XPRESSO_METHODS: frozenset = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE"})
+
+
+def _execute_xpresso_request(
+    method: str,
+    path: str,
+    payload: Optional[Dict[str, Any]] = None,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: int = 30,
+) -> Dict[str, Any]:
+    if not XPRESSO_URL or not XPRESSO_API_TOKEN or not XPRESSO_GROUP:
+        return {"status": "error",
+                "error": "XPresso is not configured — set XPRESSO_URL, XPRESSO_API_TOKEN, "
+                         "and XPRESSO_GROUP in .env."}
+    method_u = (method or "").upper()
+    if method_u not in _XPRESSO_METHODS:
+        return {"status": "error",
+                "error": f"Unsupported method '{method}'. Use one of {sorted(_XPRESSO_METHODS)}."}
+
+    url = f"{XPRESSO_URL}{path if path.startswith('/') else '/' + path}"
+    headers = {
+        "Authorization": f"Jwt {XPRESSO_API_TOKEN}",
+        "Group": XPRESSO_GROUP,
+    }
+    try:
+        resp = requests.request(
+            method_u, url, headers=headers, params=params,
+            json=payload if payload is not None else None, timeout=timeout,
+        )
+        try:
+            body: Any = resp.json()
+        except ValueError:
+            body = resp.text
+        return {
+            "status": "completed", "method": method_u, "url": url,
+            "status_code": resp.status_code, "body": body,
+        }
+    except Exception as exc:
+        return {"status": "error", "method": method_u, "url": url, "error": str(exc)}
+
+
+@mcp.tool()
+async def pyats_xpresso_request(
+    method: str,
+    path: str,
+    payload: Optional[Dict[str, Any]] = None,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: int = 30,
+) -> str:
+    """
+    Make an authenticated call to Cisco XPresso's REST API v2 (test
+    request/bundle submission and retrieval, job/bundle/profile lookup,
+    lab equipment — testbeds, clean instructions, topologies — test
+    harness/execution engine lookup, and image retrieval/pull/build).
+
+    UNVERIFIED: built from XPresso's published REST API v2 docs, not
+    tested against a live instance. Validate your first real call
+    carefully.
+
+    PRECONDITION:
+      Set in .env: XPRESSO_URL (e.g. https://xpresso.example.com),
+      XPRESSO_API_TOKEN (your API automation token, from XPresso's
+      Profile > API Token menu), XPRESSO_GROUP (your XPresso group name).
+
+    Args:
+        method:  One of GET, POST, PUT, PATCH, DELETE.
+        path:    API path, e.g. "/api/v2/testbeds" or "/api/v2/requests".
+        payload: JSON body dict for POST/PUT/PATCH (ignored for GET/DELETE).
+        params:  Query-string params dict — XPresso list/search endpoints
+                 use offset/limit pagination, e.g. {"offset": 50, "limit": 100}.
+        timeout: Request timeout in seconds (default 30).
+
+    Returns:
+        { "status": "completed", "method": "GET", "url": "...",
+          "status_code": 200, "body": {...} }
+    """
+    if not (path or "").strip():
+        return json.dumps(_err("pyats_xpresso_request", None, path, "path is empty."), indent=2)
+    try:
+        result = await _run_in_executor(_execute_xpresso_request, method, path, payload, params, timeout)
+        _log_op("pyats_xpresso_request", None, f"{method} {path}",
+                result.get("status", "error"), result.get("error"))
+        return json.dumps(result, indent=2)
+    except Exception as exc:
+        logger.error("pyats_xpresso_request failed: %s", exc, exc_info=True)
+        return json.dumps(_err("pyats_xpresso_request", None, path, str(exc)), indent=2)
+
+
+# ===========================================================================
 # SESSION / AUDIT TOOL
 # ===========================================================================
 
@@ -1660,13 +2687,15 @@ async def pyats_get_operation_log(
       At the start of a long session call this tool to check what was already
       investigated and avoid redundant round-trips.
     """
-    entries = _OP_LOG[:]
+    with _STATE_LOCK:
+        entries = _OP_LOG[:]
+        total_entries = len(_OP_LOG)
     if device_filter:
         entries = [e for e in entries if e.get("device") == device_filter]
     entries = entries[-min(limit, _OP_LOG_MAX):]
     return json.dumps({
         "status": "completed",
-        "total_entries": len(_OP_LOG),
+        "total_entries": total_entries,
         "returned": len(entries),
         "filter_device": device_filter,
         "log": entries,
@@ -1675,7 +2704,36 @@ async def pyats_get_operation_log(
 
 # ---------------------------------------------------------------------------
 # Entry point
+#
+# Streamable HTTP only (STDIO removed). PYATS_MCP_TRANSPORT_MODE selects:
+#   stateful  (default) — stateless_http=False, server retains HTTP-session
+#                          state for clients still on the pre-SEP-2575 (legacy
+#                          2025-06-18) handshake-based protocol.
+#   stateless           — stateless_http=True, no HTTP-session state kept
+#                          between requests even for legacy-protocol clients.
+# Clients speaking the current 2026-07-28 protocol core are handshake-free
+# and per-request-metadata-based regardless of this flag — that behavior
+# comes from the mcp>=2.0.0 SDK itself, not from anything configured here.
 # ---------------------------------------------------------------------------
+_TRANSPORT_MODE: str = os.getenv("PYATS_MCP_TRANSPORT_MODE", "stateful").strip().lower()
+if _TRANSPORT_MODE not in ("stateful", "stateless"):
+    logger.warning(
+        "Invalid PYATS_MCP_TRANSPORT_MODE=%r; defaulting to 'stateful'", _TRANSPORT_MODE
+    )
+    _TRANSPORT_MODE = "stateful"
+
+_HTTP_HOST: str = os.getenv("PYATS_MCP_HTTP_HOST", "0.0.0.0")
+_HTTP_PORT: int = _parse_int_env("PYATS_MCP_HTTP_PORT", 8080)
+
 if __name__ == "__main__":
-    logger.info("Starting pyATS MCP Server …")
-    mcp.run()
+    logger.info(
+        "Starting pyATS MCP Server — transport=streamable-http mode=%s host=%s port=%d",
+        _TRANSPORT_MODE, _HTTP_HOST, _HTTP_PORT,
+    )
+    mcp.run(
+        transport="streamable-http",
+        host=_HTTP_HOST,
+        port=_HTTP_PORT,
+        json_response=True,
+        stateless_http=(_TRANSPORT_MODE == "stateless"),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,11 @@ requires-python = ">=3.10"
 license = {text = "MIT"}
 dependencies = [
     "pyats[full]==25.2.0",
-    "mcp>=1.0.0,<2.0.0",
+    "setuptools<81",
+    "mcp>=2.0.0,<3.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
+    "requests>=2.31.0,<3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pyats[full]==25.2.0
-mcp>=1.0.0,<2.0.0
+setuptools<81
+mcp>=2.0.0,<3.0.0
 pydantic>=2.0.0,<3.0.0
 python-dotenv>=1.0.0,<2.0.0
+requests>=2.31.0,<3.0.0

--- a/test_pyats_mcp_server.py
+++ b/test_pyats_mcp_server.py
@@ -34,13 +34,16 @@ def _make_stub_modules():
         "dotenv": types.ModuleType("dotenv"),
         "pyats": types.ModuleType("pyats"),
         "pyats.topology": types.ModuleType("pyats.topology"),
+        "pyats.async_": types.ModuleType("pyats.async_"),
         "genie": types.ModuleType("genie"),
         "genie.libs": types.ModuleType("genie.libs"),
         "genie.libs.parser": types.ModuleType("genie.libs.parser"),
         "genie.libs.parser.utils": types.ModuleType("genie.libs.parser.utils"),
+        "genie.utils": types.ModuleType("genie.utils"),
+        "genie.utils.diff": types.ModuleType("genie.utils.diff"),
         "mcp": types.ModuleType("mcp"),
         "mcp.server": types.ModuleType("mcp.server"),
-        "mcp.server.fastmcp": types.ModuleType("mcp.server.fastmcp"),
+        "mcp.server.mcpserver": types.ModuleType("mcp.server.mcpserver"),
     }
 
     # dotenv
@@ -50,21 +53,28 @@ def _make_stub_modules():
     mock_loader = MagicMock()
     stubs["pyats.topology"].loader = mock_loader  # type: ignore[attr-defined]
 
+    # pyats.async_.pcall — real tests patch srv._pcall_show_command /
+    # srv._pcall_configure_devices directly, so this stub only needs to exist.
+    stubs["pyats.async_"].pcall = MagicMock()  # type: ignore[attr-defined]
+
     # genie parser utility
     stubs["genie.libs.parser.utils"].get_parser = MagicMock(return_value=None)  # type: ignore[attr-defined]
 
-    # FastMCP stub — decorators become no-ops that return the original function
-    class _FakeFastMCP:
+    # genie.utils.diff.Diff — real tests patch srv.Diff directly when needed.
+    stubs["genie.utils.diff"].Diff = MagicMock()  # type: ignore[attr-defined]
+
+    # MCPServer stub — decorators become no-ops that return the original function
+    class _FakeMCPServer:
         def __init__(self, *args, **kwargs):
             pass
         def tool(self):
             def decorator(fn):
                 return fn
             return decorator
-        def run(self):
+        def run(self, *args, **kwargs):
             pass
 
-    stubs["mcp.server.fastmcp"].FastMCP = _FakeFastMCP  # type: ignore[attr-defined]
+    stubs["mcp.server.mcpserver"].MCPServer = _FakeMCPServer  # type: ignore[attr-defined]
 
     for name, mod in stubs.items():
         sys.modules.setdefault(name, mod)
@@ -88,8 +98,8 @@ def _json(result: str) -> dict:
 
 
 def _run(coro):
-    """Run a coroutine synchronously (Python < 3.11 compatible)."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    """Run a coroutine synchronously."""
+    return asyncio.run(coro)
 
 
 def _mock_device(name: str = "router-1", connected: bool = True) -> MagicMock:
@@ -821,6 +831,302 @@ class TestNormalizeConfigEdgeCases(unittest.TestCase):
         for wrapper in ["configure terminal", "conf t", "config t", "configure t", "end"]:
             result = fn([wrapper, "ntp server 1.1.1.1"])
             assert wrapper not in result
+
+
+# ---------------------------------------------------------------------------
+# New tools: pcall, learn/diff, clean, blitz, robot, rest, xpresso
+# ---------------------------------------------------------------------------
+
+class TestPyatsPcallShowCommand(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+
+    def test_runs_across_all_devices(self):
+        canned = [
+            {"status": "completed", "device": "r1", "command": "show version", "output": "ok"},
+            {"status": "completed", "device": "r2", "command": "show version", "output": "ok"},
+        ]
+        with patch.object(srv, "_pcall_show_command", return_value=canned):
+            result = _json(_run(srv.pyats_pcall_show_command(["r1", "r2"], "show version")))
+        assert result["status"] == "completed"
+        assert result["concurrency"] == "pcall (process per device)"
+        assert result["summary"] == {"total": 2, "success": 2, "failed": 0}
+
+    def test_empty_device_list_returns_error(self):
+        result = _json(_run(srv.pyats_pcall_show_command([], "show version")))
+        assert result["status"] == "error"
+
+    def test_invalid_command_returns_error(self):
+        result = _json(_run(srv.pyats_pcall_show_command(["r1"], "reload")))
+        assert result["status"] == "error"
+
+    def test_partial_failure_reflected_in_summary(self):
+        canned = [
+            {"status": "completed", "device": "r1", "command": "show version", "output": "ok"},
+            {"status": "error", "device": "r2", "error": "timeout"},
+        ]
+        with patch.object(srv, "_pcall_show_command", return_value=canned):
+            result = _json(_run(srv.pyats_pcall_show_command(["r1", "r2"], "show version")))
+        assert result["summary"] == {"total": 2, "success": 1, "failed": 1}
+
+
+class TestPyatsPcallConfigureDevices(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+
+    def test_configures_all_devices(self):
+        canned = [
+            {"status": "success", "device": "r1", "commands_applied": ["ntp server 1.1.1.1"]},
+            {"status": "success", "device": "r2", "commands_applied": ["ntp server 1.1.1.1"]},
+        ]
+        with patch.object(srv, "_pcall_configure_devices", return_value=canned):
+            result = _json(_run(
+                srv.pyats_pcall_configure_devices(["r1", "r2"], ["ntp server 1.1.1.1"])
+            ))
+        assert result["concurrency"] == "pcall (process per device)"
+        assert result["summary"] == {"total": 2, "success": 2, "failed": 0}
+
+    def test_empty_device_list_returns_error(self):
+        result = _json(_run(srv.pyats_pcall_configure_devices([], ["ntp server 1.1.1.1"])))
+        assert result["status"] == "error"
+
+
+class TestPyatsLearnFeature(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+        srv._learn_snapshots.clear()
+
+    def test_learn_without_snapshot(self):
+        learned = {"status": "completed", "device": "r1", "feature": "interface",
+                   "learned": {"Gi0/0": {"oper_status": "up"}}}
+        with patch.object(srv, "_execute_learn_feature", return_value=learned):
+            result = _json(_run(srv.pyats_learn_feature("r1", "interface")))
+        assert result["status"] == "completed"
+        assert "snapshot_saved" not in result
+        assert srv._learn_snapshots == {}
+
+    def test_learn_with_snapshot_label_saves_it(self):
+        learned = {"status": "completed", "device": "r1", "feature": "interface",
+                   "learned": {"Gi0/0": {"oper_status": "up"}}}
+        with patch.object(srv, "_execute_learn_feature", return_value=learned):
+            result = _json(_run(srv.pyats_learn_feature("r1", "interface", "baseline")))
+        assert result["snapshot_saved"] == "baseline"
+        assert srv._learn_snapshots["r1:interface:baseline"] == learned["learned"]
+
+    def test_error_result_not_saved_as_snapshot(self):
+        errored = {"status": "error", "device": "r1", "feature": "interface", "error": "conn fail"}
+        with patch.object(srv, "_execute_learn_feature", return_value=errored):
+            result = _json(_run(srv.pyats_learn_feature("r1", "interface", "baseline")))
+        assert result["status"] == "error"
+        assert srv._learn_snapshots == {}
+
+
+class TestPyatsDiffLearnedSnapshots(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+        srv._learn_snapshots.clear()
+
+    def test_missing_snapshot_returns_error(self):
+        result = _json(_run(
+            srv.pyats_diff_learned_snapshots("r1", "interface", "before", "after")
+        ))
+        assert result["status"] == "error"
+        assert "before" in result["error"] and "after" in result["error"]
+
+    def test_diff_of_two_snapshots(self):
+        srv._learn_snapshots["r1:interface:before"] = {"Gi0/0": {"status": "up"}}
+        srv._learn_snapshots["r1:interface:after"] = {"Gi0/0": {"status": "down"}}
+        with patch.object(srv, "Diff") as mock_diff_cls:
+            mock_diff = MagicMock()
+            mock_diff.__str__.return_value = "- status: up\n+ status: down"
+            mock_diff_cls.return_value = mock_diff
+            result = _json(_run(
+                srv.pyats_diff_learned_snapshots("r1", "interface", "before", "after")
+            ))
+        assert result["status"] == "completed"
+        assert "down" in result["diff"]
+        mock_diff.findDiff.assert_called_once()
+
+
+class TestBlitzGuardrails(unittest.TestCase):
+    def test_allows_safe_actions(self):
+        assert srv._blitz_guardrails("- step1:\n  - execute:\n      command: show version\n") is None
+
+    def test_blocks_reload(self):
+        assert srv._blitz_guardrails("- step1:\n  - execute:\n      command: reload\n") is not None
+
+    def test_blocks_write_erase(self):
+        assert srv._blitz_guardrails("command: write erase") is not None
+
+
+class TestPyatsRunBlitz(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+
+    def test_empty_actions_yaml_returns_error(self):
+        result = _json(_run(srv.pyats_run_blitz("", ["r1"])))
+        assert result["status"] == "error"
+
+    def test_empty_device_list_returns_error(self):
+        result = _json(_run(srv.pyats_run_blitz("- step1:\n  - execute:\n      command: show version\n", [])))
+        assert result["status"] == "error"
+
+    def test_dangerous_action_blocked(self):
+        result = _json(_run(srv.pyats_run_blitz("command: reload", ["r1"])))
+        assert result["status"] == "error"
+
+    def test_success_path(self):
+        mock_result = {"status": "completed", "returncode": 0, "overall_result": "PASSED",
+                       "stdout": "", "stderr": "", "report": None,
+                       "trigger_datafile": "/tmp/t.yaml", "archive": None,
+                       "artifacts_dir": "/tmp/run"}
+        with patch.object(srv, "_run_blitz", return_value=mock_result):
+            result = _json(_run(
+                srv.pyats_run_blitz("- step1:\n  - execute:\n      command: show version\n", ["r1"])
+            ))
+        assert result["overall_result"] == "PASSED"
+
+
+class TestRobotGuardrails(unittest.TestCase):
+    def test_allows_safe_script(self):
+        assert srv._robot_guardrails('Connect To Device "R1"') is None
+
+    def test_blocks_reload(self):
+        assert srv._robot_guardrails("Execute Command    reload") is not None
+
+
+class TestPyatsRunRobot(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+
+    def test_empty_script_returns_error(self):
+        result = _json(_run(srv.pyats_run_robot("")))
+        assert result["status"] == "error"
+
+    def test_dangerous_script_blocked(self):
+        result = _json(_run(srv.pyats_run_robot("Execute Command    erase startup-config")))
+        assert result["status"] == "error"
+
+    def test_success_path(self):
+        mock_result = {"status": "completed", "overall_result": "PASSED", "returncode": 0,
+                       "stdout": "1 test, 1 passed, 0 failed", "stderr": "",
+                       "artifacts_dir": "/tmp/run", "paths": {}}
+        with patch.object(srv, "_run_robot_script", return_value=mock_result):
+            result = _json(_run(srv.pyats_run_robot("*** Test Cases ***\nT1\n    No Operation\n")))
+        assert result["overall_result"] == "PASSED"
+
+
+class TestPyatsCleanDevice(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+
+    def test_empty_commands_returns_error(self):
+        result = _json(_run(srv.pyats_clean_device("r1", [])))
+        assert result["status"] == "error"
+
+    def test_dangerous_command_blocked(self):
+        result = _json(_run(srv.pyats_clean_device("r1", ["reload"])))
+        assert result["status"] == "error"
+
+    def test_dry_run_returns_yaml_without_subprocess(self):
+        with patch.object(srv, "_execute_clean_device") as mock_exec:
+            result = _json(_run(srv.pyats_clean_device("r1", ["show version"])))
+        mock_exec.assert_not_called()
+        assert result["status"] == "completed"
+        assert result["dry_run"] is True
+        assert "execute_command" in result["clean_yaml"]
+
+    def test_real_run_requires_confirm_phrase(self):
+        result = _json(_run(
+            srv.pyats_clean_device("r1", ["show version"], dry_run=False, confirm="nope")
+        ))
+        assert result["status"] == "error"
+
+    def test_real_run_with_correct_confirm(self):
+        mock_result = {"status": "completed", "device": "r1", "returncode": 0,
+                       "stdout": "", "stderr": "", "clean_yaml": "...", "artifacts_dir": "/tmp/run"}
+        with patch.object(srv, "_execute_clean_device", return_value=mock_result) as mock_exec:
+            result = _json(_run(srv.pyats_clean_device(
+                "r1", ["show version"], dry_run=False, confirm=srv._CLEAN_CONFIRM_PHRASE,
+            )))
+        mock_exec.assert_called_once()
+        assert result["status"] == "completed"
+
+
+class TestPyatsRestRequest(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+
+    def test_no_rest_block_returns_clean_error(self):
+        dev = _mock_device("r1")  # connections has no "rest" key
+        tb = MagicMock()
+        tb.devices = {"r1": dev}
+        with patch.object(srv, "_load_testbed", return_value=tb):
+            result = _json(_run(srv.pyats_rest_request("r1", "GET", "/restconf/data/x")))
+        assert result["status"] == "error"
+        assert "rest" in result["error"].lower()
+
+    def test_unsupported_method_returns_error(self):
+        dev = _mock_device("r1")
+        dev.connections = {"rest": MagicMock()}
+        tb = MagicMock()
+        tb.devices = {"r1": dev}
+        with patch.object(srv, "_load_testbed", return_value=tb):
+            result = _json(_run(srv.pyats_rest_request("r1", "TRACE", "/restconf/data/x")))
+        assert result["status"] == "error"
+
+    def test_get_success(self):
+        dev = _mock_device("r1")
+        dev.connections = {"rest": MagicMock()}
+        dev.rest = MagicMock()
+        dev.rest.connected = True
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = '{"ietf-interfaces:interfaces": {}}'
+        dev.rest.get.return_value = resp
+        tb = MagicMock()
+        tb.devices = {"r1": dev}
+        with patch.object(srv, "_load_testbed", return_value=tb):
+            result = _json(_run(
+                srv.pyats_rest_request("r1", "GET", "/restconf/data/ietf-interfaces:interfaces")
+            ))
+        assert result["status"] == "completed"
+        assert result["status_code"] == 200
+        assert result["body"] == {"ietf-interfaces:interfaces": {}}
+
+
+class TestPyatsXpressoRequest(unittest.TestCase):
+    def setUp(self):
+        srv._OP_LOG.clear()
+        self._url, self._token, self._group = srv.XPRESSO_URL, srv.XPRESSO_API_TOKEN, srv.XPRESSO_GROUP
+
+    def tearDown(self):
+        srv.XPRESSO_URL, srv.XPRESSO_API_TOKEN, srv.XPRESSO_GROUP = self._url, self._token, self._group
+
+    def test_not_configured_returns_clear_error(self):
+        srv.XPRESSO_URL, srv.XPRESSO_API_TOKEN, srv.XPRESSO_GROUP = "", "", ""
+        result = _json(_run(srv.pyats_xpresso_request("GET", "/api/v2/testbeds")))
+        assert result["status"] == "error"
+        assert "XPRESSO_URL" in result["error"]
+
+    def test_empty_path_returns_error(self):
+        result = _json(_run(srv.pyats_xpresso_request("GET", "")))
+        assert result["status"] == "error"
+
+    def test_get_success(self):
+        srv.XPRESSO_URL, srv.XPRESSO_API_TOKEN, srv.XPRESSO_GROUP = (
+            "https://xpresso.example.com", "tok123", "mygroup",
+        )
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"items": []}
+        with patch.object(srv.requests, "request", return_value=resp) as mock_req:
+            result = _json(_run(srv.pyats_xpresso_request("GET", "/api/v2/testbeds")))
+        assert result["status"] == "completed"
+        assert result["status_code"] == 200
+        called_headers = mock_req.call_args.kwargs["headers"]
+        assert called_headers["Authorization"] == "Jwt tok123"
+        assert called_headers["Group"] == "mygroup"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Migrates from STDIO to the current MCP Python SDK's Streamable HTTP transport (`mcp>=2.0.0`), switchable between stateful and stateless via `PYATS_MCP_TRANSPORT_MODE`, with a `threading.Lock` now guarding every process-global cache so concurrent HTTP clients can't race each other.
- Adds 9 new tools verified against a real CML lab: `pyats_pcall_show_command`, `pyats_pcall_configure_devices` (process-per-device fan-out), `pyats_learn_feature`, `pyats_diff_learned_snapshots` (Genie learn/diff snapshots), `pyats_clean_device` (Genie Clean, non-destructive stages only, dry-run by default), `pyats_run_blitz`, `pyats_run_robot`, `pyats_rest_request`, `pyats_xpresso_request`.
- Fixes two pre-existing bugs found along the way: `pyats_run_dynamic_test`'s `--json-job` flag was silently producing no report (now reads the real report from the job's archive), and Blitz jobs failed outright because `genie.harness`'s `common_setup` tried to connect every testbed device instead of just the ones a trigger targets.
- Adds a `benchmark/` harness comparing STDIO vs. Streamable HTTP (stateful/stateless), 34 new unit tests (119 total, all passing), and a rewritten README (transport, all 26 tools, and how to wire up Claude Code / VS Code Copilot / Codex CLI / Claude Desktop / raw Python).

## Test plan
- [x] `pytest` — 119/119 passing
- [x] Live-tested every new tool (except `pyats_pcall_configure_devices` and `pyats_xpresso_request`, deliberately not fired for real) against a real CML lab in both stateful and stateless HTTP mode
- [x] Full pre/post benchmark run against real devices, results in `benchmark/results/`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>